### PR TITLE
Some minor UI/UX fixes for Linux, Ubuntu

### DIFF
--- a/src/lib/components/Controls/Settings/index.svelte
+++ b/src/lib/components/Controls/Settings/index.svelte
@@ -64,9 +64,12 @@
     border-radius: 50%;
     aspect-ratio: 4/4;
   }
+  #settings-box {
+    position: relative;
+  }
   .settings-box {
     position: absolute;
-    left: 0;
+    right: 0;
     top: 70px;
     height: 58vh;
     padding: 5px 20px;

--- a/src/styles.css
+++ b/src/styles.css
@@ -35,12 +35,9 @@ img {
   pointer-events: none;
 }
 
-input[type="range"]{
+input[type="range"] {
+  -webkit-appearance: none;
   appearance: none;
-  /* outline: none; */
-  display: flex;
-  justify-content: center;
-  align-items: center;
   background-color: transparent;
   cursor: grab;
   opacity: 0.8;
@@ -54,15 +51,12 @@ input[type="range"]:hover {
 input[type="range"]:active{
   cursor: grabbing;
 }
-::-webkit-slider-runnable-track{
+::-webkit-slider-runnable-track {
+  -webkit-appearance: none;
   appearance: none;
   background-color: #00000070;
   border-radius: 10px;
   height: 3px;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  text-align: center;
 }
 ::-webkit-slider-thumb{
   appearance: none;

--- a/src/styles.css
+++ b/src/styles.css
@@ -41,7 +41,6 @@ input[type="range"] {
   background-color: transparent;
   cursor: grab;
   opacity: 0.8;
-  transition: opacity 0.2s;
 }
 
 input[type="range"]:hover {


### PR DESCRIPTION
I encountered 3 unpleasant moments on Linux, Ubuntu, which I decided to fix.

1. The sound panel was displayed under the panel with tracks (on the left, although it should have been on the right). Now it is displayed on the right, as it should have been.
2. The dot on the slider did not correspond to the cursor position. The dot had a zero value in the center of the slider, and was 50% to the right of the cursor when the cursor dragged the dot. The dot itself went beyond the slider to the right.
3. "Shaking" slider. When hovering over the slider, it rose a little. I understand that this is a UI element, but it worsened my subjective UX. When dragging a dot on the slider, it seemed to "shake", because the cursor periodically went beyond the slider. And it was simply difficult to get the cursor on the slider.

I have not tested these changes on other systems, but I hope that they will be useful to other users of this application! It is wonderful!