### PR TITLE
Engine/app audit: fix crash + leaks, add tests, refactor volume/effect state

### DIFF
--- a/IMPROVEMENTS.md
+++ b/IMPROVEMENTS.md
@@ -1,0 +1,376 @@
+# LoFi Engine — Improvement Tracker
+
+A prioritized backlog from a comprehensive code analysis (engine + app shell).
+Each item lists **severity**, **evidence** (`file:line`), a **suggested fix**, and a
+**verification** note. Check items off as they are addressed.
+
+Severity: 🔴 high (crash / hang / accumulating leak) · 🟡 medium (quality / robustness) · 🟢 low (polish / docs)
+
+**Verification:** Initial analysis on 2026-06-29, then cross-checked by three
+parallel read-only audits (engine, tracks/effects, shell/i18n/robustness). Verdicts
+below reflect that consensus — a few original claims were corrected or downgraded
+(see BUG-3) and several new issues were found (CRIT-1 most importantly).
+
+---
+
+## Wave 1 — implementation status (branch `improvements/wave-1-fixes`)
+
+Implemented by four file-disjoint agents and centrally verified:
+**`svelte-check` → 0 errors** (1 pre-existing A11y warning in ContextMenu, out of scope),
+**Vitest → 17/17 passing**, **`vite build` → success** (6011 modules). Diff: 29 files, +853/−353, plus Vitest config + 3 specs + `melodyHelpers.ts`.
+
+- **DONE (this wave):** CRIT-1 · BUG-1 · BUG-2 · BUG-3 · BUG-4 · BUG-6 · BUG-7 · BUG-8 · BUG-9 · BUG-10 ·
+  GEN-1 · GEN-3 · GEN-4 · GEN-6 · GEN-8 · PERF-1 · PERF-2 · PERF-4 · PERF-5 · PERF-6 ·
+  ROBUST-1 · ROBUST-2 · ROBUST-3 · ROBUST-4 · SEC-2 · MISC-1 · MISC-2 · MISC-3 · MISC-4 · MISC-5 · MISC-6 · MISC-7 · MISC-8.
+  - Also extended BUG-2/MISC-8 to the instrument classes (`Hat`/`Kick`/`Snare`/`Piano`): removed the dead
+    `sampler()` methods that shadowed the field and declared the fields — this fixed **pre-existing** `svelte-check` failures.
+- **DONE but needs runtime check:** **SEC-1** — an explicit CSP was added to `tauri.conf.json`, but it must be
+  validated in a real `tauri build` (Tone.js may use blob/AudioWorklet workers; user images render as data-URLs).
+- **DEFERRED (Wave 2 — genuinely cross-cutting, would conflict in parallel):**
+  - **PERF-3** — replace the localStorage volume-polling with a shared Svelte store (touches every domain's files).
+  - **BUG-5** — make Auto-DJ effect/track toggling stateful (needs a PlayButton↔effects "set on/off" contract + reset on mode change).
+- **NOT STARTED (larger features, left as roadmap):** GEN-2 (bassline) · GEN-5 (drum-pattern variety) · GEN-7 (inversions/extensions/velocity).
+
+---
+
+## 0. Critical — fix first
+
+- [ ] **CRIT-1 🔴 Spacebar bypasses all load/generation guards → crash + freeze.**
+  `handleKeydown` calls `toggle()` directly, skipping the `allSamplesLoaded` /
+  `contextStarted` / `genChordsOnce` checks that the play button enforces in
+  `handleButtonAction`. The page is interactive during the multi-hundred-KB sample
+  load, so pressing **Space** (the natural play key) before generation runs starts
+  the Transport with `progression = []` and `scale = []`:
+  `playChord` → `progression[0].semitoneDist` throws a TypeError, and `playMelody`
+  hits the empty-scale infinite loop (see BUG-1) → main-thread freeze.
+  — `src/lib/PlayButton.svelte:152-157` (handler), `:273-275` / `:286-332` (crash sites)
+  *Fix:* route the spacebar through `handleButtonAction()`, or guard
+  `toggle()` with `if (!genChordsOnce) return;`.
+  *Verification:* CONFIRMED (EngineAudit). New finding; combines BUG-1 + BUG-6.
+
+---
+
+## A. Music generation quality
+
+- [ ] **GEN-1 🟡 Melody ignores the current chord (no chord-tone awareness).**
+  `playMelody()` random-walks the *key's* major scale and never references
+  `progression[progress]`. — `src/lib/PlayButton.svelte:286-332`
+  *Nuance (confirmed):* chords (`key+"3"`) and melody (scale on `key+"5"`) share the
+  same key, so output is always **in-key** — not atonal. The defect is no chord-tone
+  *targeting*, allowing diatonic "avoid notes" on strong beats.
+  *Fix:* bias selection toward the active chord's tones on strong beats.
+  *Verification:* CONFIRMED (EngineAudit).
+
+- [ ] **GEN-2 🟡 No bassline.** Arrangement is chords (oct 3) + melody (oct 5) +
+  drums; lofi almost always has bass. — `src/lib/PlayButton.svelte`
+  *Fix:* add a bass sequence following chord roots (oct 1–2).
+
+- [ ] **GEN-3 🟡 Tempo/swing hardcoded and atypical.** `bpm = 156`, `swing = 1`
+  (max), never varied. — `src/lib/PlayButton.svelte:47-48`
+  *Fix:* lower/vary BPM (or half-time feel), reduce swing to ~0.3–0.6.
+  *Verification:* CONFIRMED (EngineAudit — only those two lines touch bpm/swing).
+
+- [ ] **GEN-4 🟡 Biased shuffle + no voice-leading in voicings.**
+  `generateVoicing()` uses `sort(() => Math.random()-0.5)` (non-uniform) and is
+  re-run fresh per chord with no reference to the previous voicing.
+  — `src/lib/engine/Chords/Chord.ts:31-43`; called at `PlayButton.svelte:277`
+  *Nuance:* the octave-stacking loop forces a monotonic spread, so the shuffle
+  randomizes *spread*, not pitch content.
+  *Fix:* Fisher–Yates shuffle; keep common tones between consecutive chords.
+  *Verification:* CONFIRMED (EngineAudit).
+
+- [ ] **GEN-5 🟡 Drum patterns are static.** Sections only flip drums on/off and
+  tweak per-hit probability; the kick/snare/hat arrays never change.
+  — `src/lib/PlayButton.svelte:102-143, 192-223`
+  *Fix:* small pattern library + occasional fills, swapped on section boundaries.
+
+- [ ] **GEN-6 🟡 Progressions wander; no cadence.** `nextChordIdx()` picks
+  uniformly among allowed nexts; progression starts on a random chord and never
+  targets a resolving cadence to I; `IntervalWeights` is melody-only.
+  — `engine/Chords/Chord.ts:28`, `ChordProgression.ts:10`, `Chords.ts`
+  *Fix:* weight transitions and force a cadence (V→I / ii–V–I) at phrase ends.
+  *Verification:* CONFIRMED (EngineAudit — IntervalWeights never imported under `Chords/`).
+
+- [ ] **GEN-7 🟢 Narrow harmonic palette.** Same extended-7th voicing template
+  every chord, root pinned to oct 3, no inversions/sus/9ths, no velocity dynamics.
+  — `engine/Chords/Chords.ts`, `PlayButton.svelte:273-284`
+  *Fix:* inversions, occasional extensions, humanized velocity.
+
+- [ ] **GEN-8 🟡 Master low-pass filter settles at 1200 Hz, not its initial 2000 Hz.**
+  `autoDJTransition` ramps the master LPF 2000→300→**1200** and never restores
+  2000, so the whole mix is permanently darker after the first section change.
+  — `src/lib/PlayButton.svelte:44, 264-267`
+  *Fix:* ramp back to the original cutoff (2000) after the transition.
+  *Verification:* CONFIRMED (EngineAudit); likely unintended.
+
+---
+
+## B. Logic / correctness bugs
+
+- [ ] **BUG-1 🔴 Unbounded `while(!found)` in the melody weighted picker → hang.**
+  The loop has no bounds guard; if `scaleDist` runs past the array end,
+  `weights[scaleDist]` is `undefined` and `randomWeight <= undefined` is always
+  false → infinite loop on the audio thread.
+  — `src/lib/PlayButton.svelte:315-324`
+  *Verification (EngineAudit):* CONFIRMED. The float-rounding path is real but
+  vanishingly rare (~1e-16/note). The **reachable** trigger is an empty `scale`
+  (`weights = []` → `weights[0] === undefined`), which is exactly the pre-generation
+  state reached via the spacebar path (CRIT-1).
+  *Fix:* clamp `scaleDist` to `weights.length - 1` and bail if `weights` is empty.
+  (The random-walk index itself is NOT otherwise out of bounds — REFUTED for normal
+  operation; `scale.length` is always 15 and the step math stays in `[0,14]`.)
+
+- [ ] **BUG-2 🟡 Dead / shadowed methods in `Chord`.** Constructor assigns
+  `degree/semitoneDist/intervals/nextChordIdxs` as instance properties that shadow
+  the same-named prototype methods, making them uncallable; `generateMode()` is
+  never called. — `engine/Chords/Chord.ts:5-25, 45-52`
+  *Fix:* delete the four dead accessors + `generateMode()`; keep properties +
+  `nextChordIdx()` / `generateVoicing()`.
+  *Verification:* CONFIRMED (EngineAudit — zero call sites of the four as functions).
+
+- [ ] **BUG-3 🟡 `pauseTrack` leaks audio entries (NOT overlapping playback).**
+  `TrackListItem.pauseTrack()` pauses the audio but never removes it from
+  `activeAudios` (parent `toggleTrack` *does* filter), so repeated play/pause
+  accumulates `Audio` objects. — `TrackListItem.svelte:58-65` vs `TrackList/index.svelte:152-160`
+  *Verification (TracksAudit):* leak CONFIRMED; **"overlapping playback" REFUTED** —
+  `pauseTrack` pauses *every* entry with the matching id, so duplicates never play
+  simultaneously. (Severity downgraded from 🔴 to 🟡.)
+  *Fix:* remove the entry from `activeAudios` on pause (single source of truth).
+
+- [ ] **BUG-4 🟡 Three desynced code paths control the same track state.**
+  `TrackListItem.play/pauseTrack`, parent `toggleTrack()`, and the number-key (1–9)
+  handlers each mutate state independently. `toggleTrack` ends with `tracks = tracks`
+  (re-renders children); the number-key and "k" handlers do **not**, so the child UI
+  goes stale (e.g. start a track by click, then press its number → audio stops but
+  the item still shows "playing" with its slider).
+  — `TrackList/index.svelte:73-101, 140-163`; `TrackListItem.svelte:45-65`
+  *Verification (TracksAudit):* CONFIRMED as **visual/state desync + leak**, not audio
+  overlap.
+  *Fix:* consolidate all start/stop into one function or a shared store.
+
+- [ ] **BUG-5 🟡 Auto-DJ toggles effects/tracks statelessly.** It dispatches
+  `lofi-toggle-*` (a flip, not a set), so effects fight manual toggles and are **not**
+  turned off when switching back to MUSIC mode (nothing resets them on mode change).
+  — `PlayButton.svelte:225-261`, `AutoDJ.svelte:18-24`, `handleAutoDJModeChange :163-165`
+  *Fix:* use explicit set-on/off events and reset effects/tracks on mode change.
+  *Verification:* CONFIRMED (TracksAudit).
+
+- [ ] **BUG-6 🟡 Unreachable "Initialize Audio" state + `Tone.start()` outside a
+  gesture.** The reactive block runs `startAudioContext()` + `generateProgression()`
+  the instant samples load, so `contextStarted`/`genChordsOnce` are already true
+  before any click — the "Initialize Audio" branch and the `!contextStarted` /
+  `!genChordsOnce` branches are unreachable, and that `Tone.start()` is outside a
+  user gesture (the real unlock is `toggle()`).
+  — `PlayButton.svelte:387-390, 396-406, 418-420`
+  *Fix:* simplify the state machine; unlock the context only from a user gesture.
+  *Verification:* CONFIRMED both parts (ShellAudit).
+
+- [ ] **BUG-7 🟢 Hardcoded progression length in the live-index calc.**
+  `activeProgressionIndex = (progress + 7) % 8` hardcodes 8 while `nextChord` wraps
+  on `progression.length`; the `progress===4`/`===0` section logic also assumes 8.
+  — `PlayButton.svelte:200, 205, 377` (gen length set at `:340`)
+  *Fix:* derive from `progression.length`.
+  *Verification:* CONFIRMED latent (EngineAudit); no current misbehavior.
+
+- [ ] **BUG-8 🟡 Per-track volume shares one localStorage key.**
+  `TrackListItem` writes/reads a single `"audioVolume"` key, so on reload all 9
+  tracks restore the last-adjusted value; the value is also stored as a string.
+  — `TrackListItem.svelte:35-43, 67-72`
+  *Verification (TracksAudit):* CONFIRMED with nuance — live sliders keep per-instance
+  values; the shared effect is on **persistence/restore**.
+  *Fix:* persist per-track (`audioVolume:<id>`) and coerce to a number.
+
+- [ ] **BUG-9 🟡 No `onDestroy` cleanup of audio / Tone resources.** TrackList has
+  no `onDestroy` to stop `activeAudios`; effect components never stop their `Audio`
+  on destroy; PlayButton's `onDestroy` stops `noise`/`Transport` but never
+  `.dispose()`s the 5 `Tone.Sequence`s, samplers, or effect nodes. With the leaked
+  intervals (PERF-2) holding references, audio can keep playing after unmount.
+  — `PlayButton.svelte:181-186`; effect components; `TrackList/index.svelte`
+  *Fix:* stop/dispose audio and Tone nodes in `onDestroy`.
+  *Verification:* CONFIRMED (Engine + Tracks audits).
+
+- [ ] **BUG-10 🟢 `activeAudios` reference split between parent and children.**
+  The "k" and number-key handlers reassign `activeAudios = …filter/[]` without
+  `tracks = tracks`, so children keep the *old* array reference while the parent
+  holds a new one. A child `playTrack` then pushes into the stale array → that audio
+  can't be stopped by "k". — `TrackList/index.svelte:64, 93-95` vs `toggleTrack:162`
+  *Fix:* single source of truth (store / consistent reassignment).
+  *Verification:* CONFIRMED (TracksAudit).
+
+---
+
+## C. Resource leaks / performance
+
+- [ ] **PERF-1 🟡 Event listeners registered at top-of-script with no removal.**
+  Many components add `window`/`document` listeners outside `onMount` and never
+  remove them. — effect components (`Rain:24`, `Thunder:23`, `Jungle:23`,
+  `CampFire:23`), `Settings/index.svelte:18,42`, `Background.svelte:246,253,258`,
+  `TrackList/index.svelte:58,74(×9),105`
+  *Verification (ShellAudit) — important nuance:* most of these components mount
+  once at app start and never unmount, so they don't *accumulate*. The genuine
+  **accumulating** leak is **`Background.svelte`**, which is `{#if isActive}`-gated
+  and re-mounts (re-registering 3 listeners) on every settings open — and MISC-6's
+  startup double-toggle adds an extra cycle. TrackList's `onMount` cleanup also
+  omits `settings-open-changed` (`:177` added, `:179` only removes `lofi-toggle-track`).
+  *Fix:* move all listeners into `onMount` with cleanup; fix the TrackList cleanup.
+
+- [ ] **PERF-2 🟡 Uncleared `setInterval` polling.** Volume timers never cleared:
+  `PlayButton.svelte:379-385` (100 ms), `Controls/index.svelte:21-24` (200 ms, also a
+  `volumes = volumes = …` double-write), and each effect component (`Rain:33`,
+  `Thunder:32`, `Jungle:31`, `CampFire:32`, 100 ms).
+  *Fix:* clear in `onDestroy`, or remove via PERF-3.
+  *Verification:* CONFIRMED (Shell + Tracks audits).
+
+- [ ] **PERF-3 🟡 Volume sync via localStorage polling instead of a store.**
+  `Volume.svelte` writes localStorage → `Controls` polls every 200 ms → prop-drills →
+  each effect polls every 100 ms to apply. Poll-driven prop drilling.
+  *Fix:* replace with a shared Svelte `writable` store.
+  *Verification:* CONFIRMED (ShellAudit).
+
+- [ ] **PERF-4 🟡 Tooltip cleanup removes the wrong listener (no-op).**
+  An anonymous `mouseout` handler is registered but cleanup calls
+  `removeEventListener("mouseout", hide)` with a function that was never registered,
+  so removal does nothing (despite a `// Fix listener removal` comment).
+  — `src/lib/components/Tooltip.svelte:64-74, 84`
+  *Fix:* store the handler in a named const and remove that reference.
+  *Verification:* CONFIRMED new finding (ShellAudit).
+
+- [ ] **PERF-5 🟢 Window-control polling + imperative listeners never cleaned.**
+  `MacControls.svelte:33-43` and `GenericControls.svelte:34-44` poll
+  `appWindow.isMaximized()` every 300 ms with no cleanup, and attach click listeners
+  via `getElementById(...).addEventListener` (`:13-29` / `:15-30`) that are never
+  removed (and bypass Svelte's `on:click`).
+  *Fix:* use Tauri window events + `on:click`; clear the interval in `onDestroy`.
+  *Verification:* CONFIRMED new finding (ShellAudit).
+
+- [ ] **PERF-6 🟢 Redundant/uncleaned global side effects.**
+  `Config.svelte:7-13` adds a `document` contextmenu `preventDefault` at script-eval
+  time, never removed and redundant with `ContextMenu.svelte:20-21`.
+  *Fix:* consolidate into the ContextMenu component with cleanup.
+  *Verification:* CONFIRMED new finding (ShellAudit).
+
+---
+
+## D. Robustness / error handling
+
+- [ ] **ROBUST-1 🟡 Unguarded `JSON.parse(localStorage…)` at init.** Corrupt storage
+  throws synchronously and breaks init. — `PlayButton.svelte:31-32`,
+  `Controls/index.svelte:17-18` (re-parsed every 200 ms), `Volume.svelte:12-13`,
+  `Background.svelte:82`, `App.svelte:28`
+  *Fix:* `try/catch` with the default fallback. (Absent-key is safe: `JSON.parse(null)`→null.)
+  *Verification:* CONFIRMED (ShellAudit).
+
+- [ ] **ROBUST-2 🟡 Unhandled `audio.play()` rejections.** No `.catch`/await on any
+  `play()`; rapid toggling yields unhandled `AbortError`. — all effect/track callers
+  (`Rain:15`, `Thunder:13`, `Jungle:13`, `CampFire:13`, `TrackListItem.svelte:48`,
+  `TrackList:144, 81`)
+  *Fix:* `.catch()` and ignore `AbortError`.
+  *Verification:* CONFIRMED (TracksAudit).
+
+- [ ] **ROBUST-3 🟡 Shortcuts fire while typing in inputs.** Only the two arrow
+  handlers guard `e.target.closest("input")`; effect letters (a/s/d/f), Settings 'j',
+  TrackList 'k' and 1–9 do not. Also PlayButton's spacebar always `preventDefault()`s
+  Space even when an input is focused. — effect components, `Settings/index.svelte:19`,
+  `TrackList:59,73-101`, `PlayButton.svelte:152-157`
+  *Verification (Shell + Tracks):* CONFIRMED; practical impact currently **low** (no
+  free-text inputs — only range sliders + a file input), but the pattern is fragile.
+  *Fix:* shared guard that ignores inputs/textareas/contenteditable.
+
+- [ ] **ROBUST-4 🟡 `ru.ts` is not type-checked + unguarded locale lookup.**
+  `ru.ts` declares `export const ru = {` with no `: Translations` annotation (unlike
+  ja/zh/hi/fr/nl), so `svelte-check` won't catch key drift in the Russian locale; and
+  `TrackListItem.svelte:100` does unguarded `$t.tracks[track.id].quote`, which throws
+  at render if any locale's `tracks` map drifts. — `src/lib/locales/ru.ts:1`
+  *Fix:* annotate `export const ru: Translations`; guard the lookup.
+  *Verification:* CONFIRMED new finding (ShellAudit).
+
+---
+
+## E. Security (Tauri)
+
+- [ ] **SEC-1 🟡 No Content Security Policy.** `security.csp` is `null`, disabling a
+  defense-in-depth layer flagged by Tauri's own guidance. Risk is moderated (local
+  assets; user images rendered as `background-image`/`<img>` data-URLs, not script).
+  — `src-tauri/tauri.conf.json:39-41`
+  *Fix:* set an explicit restrictive CSP.
+  *Verification:* CONFIRMED new finding (ShellAudit).
+
+- [ ] **SEC-2 🟢 External link missing `rel="noopener noreferrer"`.**
+  `<a target="_blank">` to GitHub without `rel`. — `InfoBox/SocialLinks.svelte:21`
+  *Fix:* add `rel="noopener noreferrer"`.
+  *Verification:* CONFIRMED new finding (ShellAudit).
+
+---
+
+## F. UX / docs / maintenance
+
+- [ ] **MISC-1 🟡 No automated tests.** No runner configured. The pure generation
+  logic (`ChordProgression`, `generateVoicing`, melody walk, weighted picker) is
+  highly testable and would catch BUG-1/CRIT-1.
+  *Fix:* add Vitest + unit tests for `engine/`.
+
+- [ ] **MISC-2 🟢 README localization list is inaccurate.** Claims Spanish/Korean/
+  Indonesian (absent), omits Chinese/Hindi/Dutch (present). Actual: en, ja, zh, hi,
+  fr, nl, ru. — `README.md:74-80` vs `locales/store.ts:11-19`
+  *Fix:* sync the README.
+  *Verification:* CONFIRMED (ShellAudit).
+
+- [ ] **MISC-3 🟢 Deprecated `Tone.Master`.** Used in `PlayButton.svelte:46,447`,
+  `Piano.ts:11`, `Noise.ts:5`, `Snare.ts:14`, `Kick.ts:12`, `Hat.ts:14`. Deprecated in
+  Tone 14 for `getDestination()`.
+  *Fix:* migrate to `getDestination()`.
+  *Verification:* CONFIRMED (ShellAudit).
+
+- [ ] **MISC-4 🟢 `dir` store ignores locale.** Derived `dir` always returns `'ltr'`
+  and `setLocale` hardcodes `'ltr'`; no live bug (all locales LTR) but silently breaks
+  any future RTL locale. — `locales/store.ts:29-31, 38`
+  *Fix:* map known RTL locales to `'rtl'`.
+  *Verification:* CONFIRMED (ShellAudit).
+
+- [ ] **MISC-5 🟢 Leftover debug log.** `console.log("activeAudios", …)` in the
+  "stop all" handler. — `TrackList/index.svelte:63`
+  *Fix:* remove.
+  *Verification:* CONFIRMED.
+
+- [ ] **MISC-6 🟢 Fragile settings-init hack.** `Settings` toggles open then closed
+  after 10 ms on mount to force-mount children so saved settings apply; this
+  double-dispatches `settings-open-changed` (flips TrackList `isMobileHidden` at
+  startup), causes a spurious Background mount/unmount (feeds PERF-1), and duplicates
+  App's background init. — `Settings/index.svelte:26-31`
+  *Fix:* apply saved settings explicitly (shared stores).
+  *Verification:* CONFIRMED (ShellAudit).
+
+- [ ] **MISC-7 🟡 ESC only closes the info box — contradicts help text + README.**
+  The Escape handler is gated on `&& visible`, so ESC can only hide; nothing opens
+  the box via keyboard, yet ShortCuts shows esc = "Show/hide This Box" and the README
+  says info is "accessible via the ESC key". (Also a top-level, never-removed
+  `document` listener.) — `InfoBox/Info.svelte:21-29`, `en.ts:55`, `README.md:86`
+  *Fix:* make ESC toggle (open + close) or correct the docs/help.
+  *Verification:* CONFIRMED new finding (ShellAudit).
+
+- [ ] **MISC-8 🟢 Dead code / unused assets.** `Chord.generateMode()` never called;
+  `generateVoicing`'s `if(size<3)` branch dead (callers always pass `size=4`); the
+  `…v3` piano velocity samples on disk are never loaded (`Samples.ts` hardcodes
+  `velocity=1`, requesting only `v1`). — `Chord.ts:45-52, 32-33`, `Piano/Samples.ts:4`
+  *Fix:* remove dead code; either use the v3 velocity layer or drop the files.
+  *Verification:* CONFIRMED (EngineAudit); sample→file mapping otherwise verified correct.
+
+---
+
+### Suggested first pass (revised after verification)
+1. **CRIT-1 + BUG-1** — the spacebar-during-load crash/freeze and the unbounded melody
+   loop are one defect chain; fix together. Highest priority.
+2. **BUG-3 / BUG-4 / BUG-9 / BUG-10** — collapse track playback onto a single source of
+   truth (store) and add `onDestroy` cleanup; resolves the leaks + UI desync at once.
+3. **PERF-1 (Background) / PERF-2 / PERF-3 / PERF-4** — fix the real accumulating leaks
+   (Background re-mount, Tooltip cleanup) and replace volume polling with a store.
+4. **GEN-1 + GEN-3 + GEN-8** — the changes that most improve perceived musical quality
+   (chord-tone targeting, sane tempo/swing, restore the master filter).
+5. **MISC-1** — add tests to lock in generation behavior and prevent regressions.
+
+### Notes (verified non-issues)
+- Chord/melody harmony is **in-key and consonant** — the engine builds correct diatonic
+  7th chords and the melody scale shares the key root. (GEN-1 is about refinement, not wrong notes.)
+- Piano sample → filename mapping (`#`→`sharp`, A/C/D#/F# × oct 1–6) is **correct**; all v1 files exist.
+- `generateProgression()` running mid-playback is **not** a true race (JS single-threaded; state is set atomically).
+- BUG-3 does **not** cause overlapping audio (duplicates are all paused together).

--- a/IMPROVEMENTS.md
+++ b/IMPROVEMENTS.md
@@ -24,11 +24,14 @@ Implemented by four file-disjoint agents and centrally verified:
   ROBUST-1 · ROBUST-2 · ROBUST-3 · ROBUST-4 · SEC-2 · MISC-1 · MISC-2 · MISC-3 · MISC-4 · MISC-5 · MISC-6 · MISC-7 · MISC-8.
   - Also extended BUG-2/MISC-8 to the instrument classes (`Hat`/`Kick`/`Snare`/`Piano`): removed the dead
     `sampler()` methods that shadowed the field and declared the fields — this fixed **pre-existing** `svelte-check` failures.
+- **DONE (Wave 2 — the cross-cutting refactors, built on shared stores):**
+  - **PERF-3** — `src/lib/stores/volumes.ts` is now the single source of truth; the 200 ms/100 ms localStorage
+    polling in Controls/PlayButton is gone, and `Volume.svelte` writes the store directly.
+  - **BUG-5** — `src/lib/stores/effects.ts` holds effect on/off state; buttons, shortcuts, the context menu, and the
+    Auto-DJ all write it (no more stateless `lofi-toggle-*` events). The Auto-DJ tracks the effects it enabled and
+    turns only those off when leaving ATMOSPHERE/WORLD — it no longer fights manual toggles or gets stuck on.
 - **DONE but needs runtime check:** **SEC-1** — an explicit CSP was added to `tauri.conf.json`, but it must be
   validated in a real `tauri build` (Tone.js may use blob/AudioWorklet workers; user images render as data-URLs).
-- **DEFERRED (Wave 2 — genuinely cross-cutting, would conflict in parallel):**
-  - **PERF-3** — replace the localStorage volume-polling with a shared Svelte store (touches every domain's files).
-  - **BUG-5** — make Auto-DJ effect/track toggling stateful (needs a PlayButton↔effects "set on/off" contract + reset on mode change).
 - **NOT STARTED (larger features, left as roadmap):** GEN-2 (bassline) · GEN-5 (drum-pattern variety) · GEN-7 (inversions/extensions/velocity).
 
 ---

--- a/README.md
+++ b/README.md
@@ -73,10 +73,10 @@ The new **Immersion** system (Auto DJ) automatically manages the soundscape for 
 LoFi Engine now speaks your language! We have added support for multiple languages to make the experience accessible to everyone.
 - **English**
 - **French** (Français)
-- **Spanish** (Español)
 - **Japanese** (日本語)
-- **Korean** (한국어)
-- **Indonesian** (Bahasa Indonesia)
+- **Chinese** (中文)
+- **Hindi** (हिन्दी)
+- **Dutch** (Nederlands)
 - **Russian** (Русский)
 - And more coming soon!
 

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "build": "vite build",
     "preview": "vite preview",
     "check": "svelte-check --tsconfig ./tsconfig.json",
+    "test": "vitest run",
     "tauri": "tauri",
     "tauri:d": "tauri dev",
     "tauri:b": "tauri build"
@@ -28,6 +29,7 @@
     "svelte-preprocess": "^5.0.0",
     "tslib": "^2.4.1",
     "typescript": "^4.9.5",
-    "vite": "^4.2.1"
+    "vite": "^4.2.1",
+    "vitest": "^0.34.6"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -51,6 +51,9 @@ importers:
       vite:
         specifier: ^4.2.1
         version: 4.5.9(@types/node@18.19.80)
+      vitest:
+        specifier: ^0.34.6
+        version: 0.34.6
 
 packages:
 
@@ -190,6 +193,10 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@jest/schemas@29.6.3':
+    resolution: {integrity: sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
   '@jridgewell/resolve-uri@3.1.2':
     resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
     engines: {node: '>=6.0.0'}
@@ -199,6 +206,9 @@ packages:
 
   '@jridgewell/trace-mapping@0.3.25':
     resolution: {integrity: sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==}
+
+  '@sinclair/typebox@0.27.10':
+    resolution: {integrity: sha512-MTBk/3jGLNB2tVxv6uLlFh1iu64iYOQ2PbdOSK3NW8JZsmlaOh2q6sdtKowBhfw8QFLmYNzTW4/oK4uATIi6ZA==}
 
   '@sveltejs/vite-plugin-svelte-inspector@1.0.4':
     resolution: {integrity: sha512-zjiuZ3yydBtwpF3bj0kQNV0YXe+iKE545QGZVTaylW3eAzFr+pJ/cwK8lZEaRp4JtaJXhD5DyWAV4AxLh6DgaQ==}
@@ -249,30 +259,35 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@tauri-apps/cli-linux-arm64-musl@2.9.1':
     resolution: {integrity: sha512-sGvy75sv55oeMulR5ArwPD28DsDQxqTzLhXCrpU9/nbFg/JImmI7k994YE9fr3V0qE3Cjk5gjLldRNv7I9sjwQ==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@tauri-apps/cli-linux-riscv64-gnu@2.9.1':
     resolution: {integrity: sha512-tEKbJydV3BdIxpAx8aGHW6VDg1xW4LlQuRD/QeFZdZNTreHJpMbJEcdvAcI+Hg6vgQpVpaoEldR9W4F6dYSLqQ==}
     engines: {node: '>= 10'}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@tauri-apps/cli-linux-x64-gnu@2.9.1':
     resolution: {integrity: sha512-mg5msXHagtHpyCVWgI01M26JeSrgE/otWyGdYcuTwyRYZYEJRTbcNt7hscOkdNlPBe7isScW7PVKbxmAjJJl4g==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@tauri-apps/cli-linux-x64-musl@2.9.1':
     resolution: {integrity: sha512-lFZEXkpDreUe3zKilvnMsrnKP9gwQudaEjDnOz/GMzbzNceIuPfFZz0cR/ky1Aoq4eSvZonPKHhROq4owz4fzg==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@tauri-apps/cli-win32-arm64-msvc@2.9.1':
     resolution: {integrity: sha512-ejc5RAp/Lm1Aj0EQHaT+Wdt5PHfdgQV5hIDV00MV6HNbIb5W4ZUFxMDaRkAg65gl9MvY2fH396riePW3RoKXDw==}
@@ -303,15 +318,54 @@ packages:
   '@tsconfig/svelte@3.0.0':
     resolution: {integrity: sha512-pYrtLtOwku/7r1i9AMONsJMVYAtk3hzOfiGNekhtq5tYBGA7unMve8RvUclKLMT3PrihvJqUmzsRGh0RP84hKg==}
 
+  '@types/chai-subset@1.3.6':
+    resolution: {integrity: sha512-m8lERkkQj+uek18hXOZuec3W/fCRTrU4hrnXjH3qhHy96ytuPaPiWGgu7sJb7tZxZonO75vYAjCvpe/e4VUwRw==}
+    peerDependencies:
+      '@types/chai': <5.2.0
+
+  '@types/chai@4.3.20':
+    resolution: {integrity: sha512-/pC9HAB5I/xMlc5FP77qjCnI16ChlJfW0tGa0IUcFn38VJrTV6DeZ60NU5KZBtaOZqjdpwTWohz5HU1RrhiYxQ==}
+
   '@types/node@18.19.80':
     resolution: {integrity: sha512-kEWeMwMeIvxYkeg1gTc01awpwLbfMRZXdIhwRcakd/KlK53jmRC26LqcbIt7fnAQTu5GzlnWmzA3H6+l1u6xxQ==}
 
   '@types/pug@2.0.10':
     resolution: {integrity: sha512-Sk/uYFOBAB7mb74XcpizmH0KOR2Pv3D2Hmrh1Dmy5BmK3MpdSa5kqZcg6EKBdklU0bFXX9gCfzvpnyUehrPIuA==}
 
+  '@vitest/expect@0.34.6':
+    resolution: {integrity: sha512-QUzKpUQRc1qC7qdGo7rMK3AkETI7w18gTCUrsNnyjjJKYiuUB9+TQK3QnR1unhCnWRC0AbKv2omLGQDF/mIjOw==}
+
+  '@vitest/runner@0.34.6':
+    resolution: {integrity: sha512-1CUQgtJSLF47NnhN+F9X2ycxUP0kLHQ/JWvNHbeBfwW8CzEGgeskzNnHDyv1ieKTltuR6sdIHV+nmR6kPxQqzQ==}
+
+  '@vitest/snapshot@0.34.6':
+    resolution: {integrity: sha512-B3OZqYn6k4VaN011D+ve+AA4whM4QkcwcrwaKwAbyyvS/NB1hCWjFIBQxAQQSQir9/RtyAAGuq+4RJmbn2dH4w==}
+
+  '@vitest/spy@0.34.6':
+    resolution: {integrity: sha512-xaCvneSaeBw/cz8ySmF7ZwGvL0lBjfvqc1LpQ/vcdHEvpLn3Ff1vAvjw+CoGn0802l++5L/pxb7whwcWAw+DUQ==}
+
+  '@vitest/utils@0.34.6':
+    resolution: {integrity: sha512-IG5aDD8S6zlvloDsnzHw0Ut5xczlF+kv2BOTo+iXfPr54Yhi5qbVOgGB1hZaVq4iJ4C/MZ2J0y15IlsV/ZcI0A==}
+
+  acorn-walk@8.3.5:
+    resolution: {integrity: sha512-HEHNfbars9v4pgpW6SO1KSPkfoS0xVOM/9UzkJltjlsHZmJasxg8aXkuZa7SMf8vKGIBhpUsPluQSqhJFCqebw==}
+    engines: {node: '>=0.4.0'}
+
+  acorn@8.17.0:
+    resolution: {integrity: sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==}
+    engines: {node: '>=0.4.0'}
+    hasBin: true
+
+  ansi-styles@5.2.0:
+    resolution: {integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==}
+    engines: {node: '>=10'}
+
   anymatch@3.1.3:
     resolution: {integrity: sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==}
     engines: {node: '>= 8'}
+
+  assertion-error@1.1.0:
+    resolution: {integrity: sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==}
 
   automation-events@7.1.8:
     resolution: {integrity: sha512-ITQAwmdjiSBGm6j7CUoxBR39MNUsuh0Nst4mI1vwWBj1VOhDKjJlF95njzN1bb+DS54j/mLWnemzs0QVMPI1sA==}
@@ -335,12 +389,26 @@ packages:
     resolution: {integrity: sha512-Db1SbgBS/fg/392AblrMJk97KggmvYhr4pB5ZIMTWtaivCPMWLkmb7m21cJvpvgK+J3nsU2CmmixNBZx4vFj/w==}
     engines: {node: '>=8.0.0'}
 
+  cac@6.7.14:
+    resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
+    engines: {node: '>=8'}
+
+  chai@4.5.0:
+    resolution: {integrity: sha512-RITGBfijLkBddZvnn8jdqoTypxvqbOLYQkGGxXzeFjVHvudaPw0HNFD9x928/eUwYWd2dPCugVqspGALTZZQKw==}
+    engines: {node: '>=4'}
+
+  check-error@1.0.3:
+    resolution: {integrity: sha512-iKEoDYaRmd1mxM90a2OEfWhjsjPpYPuQ+lMYsoxB126+t8fw7ySEO48nmDg5COTjxDI65/Y2OWpeEHk3ZOe8zg==}
+
   chokidar@3.6.0:
     resolution: {integrity: sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==}
     engines: {node: '>= 8.10.0'}
 
   concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
+
+  confbox@0.1.8:
+    resolution: {integrity: sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==}
 
   debug@4.4.0:
     resolution: {integrity: sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==}
@@ -351,6 +419,10 @@ packages:
       supports-color:
         optional: true
 
+  deep-eql@4.1.4:
+    resolution: {integrity: sha512-SUwdGfqdKOwxCPeVYjwSyRpJ7Z+fhpwIAtmCUdZIWZ/YP5R9WAsyuSgpLVDi9bjWoN2LXHNss/dk3urXtdQxGg==}
+    engines: {node: '>=6'}
+
   deepmerge@4.3.1:
     resolution: {integrity: sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==}
     engines: {node: '>=0.10.0'}
@@ -358,6 +430,10 @@ packages:
   detect-indent@6.1.0:
     resolution: {integrity: sha512-reYkTUJAZb9gUuZ2RvVCNhVHdg62RHnJ7WJl8ftMi4diZ6NWlciOzQN88pUhSELEwflJht4oQDv0F0BMlwaYtA==}
     engines: {node: '>=8'}
+
+  diff-sequences@29.6.3:
+    resolution: {integrity: sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
 
   es6-promise@3.3.1:
     resolution: {integrity: sha512-SOp9Phqvqn7jtEUxPWdWfWoLmyt2VaJ6MpvP9Comy1MceMXqE6bxvaTu4iaxpYYPzhny28Lc+M87/c2cPK6lDg==}
@@ -378,6 +454,9 @@ packages:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
+
+  get-func-name@2.0.2:
+    resolution: {integrity: sha512-8vXOvuE167CtIc3OyItco7N/dpRtBbYOsPsXCz7X/PMnlGjYjSGuZJgM1Y7mmew7BKf9BqvLX2tnOVy1BBUsxQ==}
 
   glob-parent@5.1.2:
     resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
@@ -417,6 +496,13 @@ packages:
     resolution: {integrity: sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==}
     engines: {node: '>=6'}
 
+  local-pkg@0.4.3:
+    resolution: {integrity: sha512-SFppqq5p42fe2qcZQqqEOiVRXl+WCP1MdT6k7BDEW1j++sp5fIY+/fdRQitvKgB5BrBcmrs5m/L0v2FrU5MY1g==}
+    engines: {node: '>=14'}
+
+  loupe@2.3.7:
+    resolution: {integrity: sha512-zSMINGVYkdpYSOBmLi0D1Uo7JU9nVdQKrHxC8eYlV+9YKK9WePqAlL7lSlorG/U2Fw1w0hTBmaa/jrQ3UbPHtA==}
+
   magic-string@0.30.17:
     resolution: {integrity: sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA==}
 
@@ -433,6 +519,9 @@ packages:
   mkdirp@0.5.6:
     resolution: {integrity: sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==}
     hasBin: true
+
+  mlly@1.8.2:
+    resolution: {integrity: sha512-d+ObxMQFmbt10sretNDytwt85VrbkhhUA/JBGm1MPaWJ65Cl4wOgLaB1NYvJSZ0Ef03MMEU/0xpPMXUIQ29UfA==}
 
   mri@1.2.0:
     resolution: {integrity: sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==}
@@ -453,9 +542,22 @@ packages:
   once@1.4.0:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
 
+  p-limit@4.0.0:
+    resolution: {integrity: sha512-5b0R4txpzjPWVw/cXXUResoD4hb6U/x9BH08L7nw+GN1sezDzPdxeRvpc9c433fZhBan/wusjbCsqwqm4EIBIQ==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
   path-is-absolute@1.0.1:
     resolution: {integrity: sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==}
     engines: {node: '>=0.10.0'}
+
+  pathe@1.1.2:
+    resolution: {integrity: sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==}
+
+  pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
+  pathval@1.1.1:
+    resolution: {integrity: sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==}
 
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
@@ -464,9 +566,19 @@ packages:
     resolution: {integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==}
     engines: {node: '>=8.6'}
 
+  pkg-types@1.3.1:
+    resolution: {integrity: sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==}
+
   postcss@8.5.3:
     resolution: {integrity: sha512-dle9A3yYxlBSrt8Fu+IpjGT8SY8hN0mlaA6GY8t0P5PjIOZemULz/E2Bnm/2dcUOena75OTNkHI76uZBNUUq3A==}
     engines: {node: ^10 || ^12 || >=14}
+
+  pretty-format@29.7.0:
+    resolution: {integrity: sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  react-is@18.3.1:
+    resolution: {integrity: sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==}
 
   readdirp@3.6.0:
     resolution: {integrity: sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==}
@@ -492,6 +604,9 @@ packages:
   sander@0.5.1:
     resolution: {integrity: sha512-3lVqBir7WuKDHGrKRDn/1Ye3kwpXaDOMsiRP1wd6wpZW56gJhsbp5RqQpA6JG/P+pkXizygnr1dKR8vzWaVsfA==}
 
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
   sorcery@0.11.1:
     resolution: {integrity: sha512-o7npfeJE6wi6J9l0/5LKshFzZ2rMatRiCDwYeDQaOzqdzRJwALhX7mk/A/ecg6wjMu7wdZbmXfD2S/vpOg0bdQ==}
     hasBin: true
@@ -500,12 +615,21 @@ packages:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
 
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
   standardized-audio-context@25.3.77:
     resolution: {integrity: sha512-Ki9zNz6pKcC5Pi+QPjPyVsD9GwJIJWgryji0XL9cAJXMGyn+dPOf6Qik1AHei0+UNVcc4BOCa0hWLBzlwqsW/A==}
+
+  std-env@3.10.0:
+    resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
 
   strip-indent@3.0.0:
     resolution: {integrity: sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==}
     engines: {node: '>=8'}
+
+  strip-literal@1.3.0:
+    resolution: {integrity: sha512-PugKzOsyXpArk0yWmUwqOZecSO0GH0bPoctLcqNDH9J04pVW3lflYE0ujElBGTloevcxF5MofAOZ7C5l2b+wLg==}
 
   svelte-check@3.8.6:
     resolution: {integrity: sha512-ij0u4Lw/sOTREP13BdWZjiXD/BlHE6/e2e34XzmVmsp5IN4kVa3PWP65NM32JAgwjZlwBg/+JtiNV1MM8khu0Q==}
@@ -560,6 +684,17 @@ packages:
     resolution: {integrity: sha512-vzSyuGr3eEoAtT/A6bmajosJZIUWySzY2CzB3w2pgPvnkUjGqlDnsNnA0PMO+mMAhuyMul6C2uuZzY6ELSkzyA==}
     engines: {node: '>= 8'}
 
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinypool@0.7.0:
+    resolution: {integrity: sha512-zSYNUlYSMhJ6Zdou4cJwo/p7w5nmAH17GRfU/ui3ctvjXFErXXkruT4MWW6poDeXgCaIBlGLrfU6TbTXxyGMww==}
+    engines: {node: '>=14.0.0'}
+
+  tinyspy@2.2.1:
+    resolution: {integrity: sha512-KYad6Vy5VDWV4GH3fjpseMQ/XU2BhIYP7Vzd0LG44qRWm/Yt2WCOTicFdvmgo6gWaqooMQCawTtILVQJupKu7A==}
+    engines: {node: '>=14.0.0'}
+
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
@@ -569,6 +704,10 @@ packages:
 
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
+
+  type-detect@4.1.0:
+    resolution: {integrity: sha512-Acylog8/luQ8L7il+geoSxhEkazvkslg7PSNKOX59mbB9cOveP5aq9h74Y7YU8yDpJwetzQQrfIwtf4Wp4LKcw==}
+    engines: {node: '>=4'}
 
   typescript@4.9.5:
     resolution: {integrity: sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==}
@@ -580,8 +719,16 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
+  ufo@1.6.4:
+    resolution: {integrity: sha512-JFNbkD1Svwe0KvGi8GOeLcP4kAWQ609twvCdcHxq1oSL8svv39ZuSvajcD8B+5D0eL4+s1Is2D/O6KN3qcTeRA==}
+
   undici-types@5.26.5:
     resolution: {integrity: sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==}
+
+  vite-node@0.34.6:
+    resolution: {integrity: sha512-nlBMJ9x6n7/Amaz6F3zJ97EBwR2FkzhBRxF5e+jE6LA3yi6Wtc2lyTij1OnDMIr34v5g/tVQtsVAzhT0jc5ygA==}
+    engines: {node: '>=v14.18.0'}
+    hasBin: true
 
   vite@4.5.9:
     resolution: {integrity: sha512-qK9W4xjgD3gXbC0NmdNFFnVFLMWSNiR3swj957yutwzzN16xF/E7nmtAyp1rT9hviDroQANjE4HK3H4WqWdFtw==}
@@ -619,8 +766,48 @@ packages:
       vite:
         optional: true
 
+  vitest@0.34.6:
+    resolution: {integrity: sha512-+5CALsOvbNKnS+ZHMXtuUC7nL8/7F1F2DnHGjSsszX8zCjWSSviphCb/NuS9Nzf4Q03KyyDRBAXhF/8lffME4Q==}
+    engines: {node: '>=v14.18.0'}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@vitest/browser': '*'
+      '@vitest/ui': '*'
+      happy-dom: '*'
+      jsdom: '*'
+      playwright: '*'
+      safaridriver: '*'
+      webdriverio: '*'
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@vitest/browser':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+      playwright:
+        optional: true
+      safaridriver:
+        optional: true
+      webdriverio:
+        optional: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
+    hasBin: true
+
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
+
+  yocto-queue@1.2.2:
+    resolution: {integrity: sha512-4LCcse/U2MHZ63HAJVE+v71o7yOdIe4cZ70Wpf8D/IyjDKYQLV5GD46B+hSTjJsvV5PztjvHoU580EftxjDZFQ==}
+    engines: {node: '>=12.20'}
 
 snapshots:
 
@@ -694,6 +881,10 @@ snapshots:
   '@esbuild/win32-x64@0.18.20':
     optional: true
 
+  '@jest/schemas@29.6.3':
+    dependencies:
+      '@sinclair/typebox': 0.27.10
+
   '@jridgewell/resolve-uri@3.1.2': {}
 
   '@jridgewell/sourcemap-codec@1.5.0': {}
@@ -702,6 +893,8 @@ snapshots:
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.0
+
+  '@sinclair/typebox@0.27.10': {}
 
   '@sveltejs/vite-plugin-svelte-inspector@1.0.4(@sveltejs/vite-plugin-svelte@2.5.3(svelte@3.59.2)(vite@4.5.9(@types/node@18.19.80)))(svelte@3.59.2)(vite@4.5.9(@types/node@18.19.80))':
     dependencies:
@@ -788,16 +981,60 @@ snapshots:
 
   '@tsconfig/svelte@3.0.0': {}
 
+  '@types/chai-subset@1.3.6(@types/chai@4.3.20)':
+    dependencies:
+      '@types/chai': 4.3.20
+
+  '@types/chai@4.3.20': {}
+
   '@types/node@18.19.80':
     dependencies:
       undici-types: 5.26.5
 
   '@types/pug@2.0.10': {}
 
+  '@vitest/expect@0.34.6':
+    dependencies:
+      '@vitest/spy': 0.34.6
+      '@vitest/utils': 0.34.6
+      chai: 4.5.0
+
+  '@vitest/runner@0.34.6':
+    dependencies:
+      '@vitest/utils': 0.34.6
+      p-limit: 4.0.0
+      pathe: 1.1.2
+
+  '@vitest/snapshot@0.34.6':
+    dependencies:
+      magic-string: 0.30.17
+      pathe: 1.1.2
+      pretty-format: 29.7.0
+
+  '@vitest/spy@0.34.6':
+    dependencies:
+      tinyspy: 2.2.1
+
+  '@vitest/utils@0.34.6':
+    dependencies:
+      diff-sequences: 29.6.3
+      loupe: 2.3.7
+      pretty-format: 29.7.0
+
+  acorn-walk@8.3.5:
+    dependencies:
+      acorn: 8.17.0
+
+  acorn@8.17.0: {}
+
+  ansi-styles@5.2.0: {}
+
   anymatch@3.1.3:
     dependencies:
       normalize-path: 3.0.0
       picomatch: 2.3.1
+
+  assertion-error@1.1.0: {}
 
   automation-events@7.1.8:
     dependencies:
@@ -819,6 +1056,22 @@ snapshots:
 
   buffer-crc32@1.0.0: {}
 
+  cac@6.7.14: {}
+
+  chai@4.5.0:
+    dependencies:
+      assertion-error: 1.1.0
+      check-error: 1.0.3
+      deep-eql: 4.1.4
+      get-func-name: 2.0.2
+      loupe: 2.3.7
+      pathval: 1.1.1
+      type-detect: 4.1.0
+
+  check-error@1.0.3:
+    dependencies:
+      get-func-name: 2.0.2
+
   chokidar@3.6.0:
     dependencies:
       anymatch: 3.1.3
@@ -833,13 +1086,21 @@ snapshots:
 
   concat-map@0.0.1: {}
 
+  confbox@0.1.8: {}
+
   debug@4.4.0:
     dependencies:
       ms: 2.1.3
 
+  deep-eql@4.1.4:
+    dependencies:
+      type-detect: 4.1.0
+
   deepmerge@4.3.1: {}
 
   detect-indent@6.1.0: {}
+
+  diff-sequences@29.6.3: {}
 
   es6-promise@3.3.1: {}
 
@@ -877,6 +1138,8 @@ snapshots:
   fsevents@2.3.3:
     optional: true
 
+  get-func-name@2.0.2: {}
+
   glob-parent@5.1.2:
     dependencies:
       is-glob: 4.0.3
@@ -913,6 +1176,12 @@ snapshots:
 
   kleur@4.1.5: {}
 
+  local-pkg@0.4.3: {}
+
+  loupe@2.3.7:
+    dependencies:
+      get-func-name: 2.0.2
+
   magic-string@0.30.17:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.0
@@ -929,6 +1198,13 @@ snapshots:
     dependencies:
       minimist: 1.2.8
 
+  mlly@1.8.2:
+    dependencies:
+      acorn: 8.17.0
+      pathe: 2.0.3
+      pkg-types: 1.3.1
+      ufo: 1.6.4
+
   mri@1.2.0: {}
 
   ms@2.1.3: {}
@@ -941,17 +1217,41 @@ snapshots:
     dependencies:
       wrappy: 1.0.2
 
+  p-limit@4.0.0:
+    dependencies:
+      yocto-queue: 1.2.2
+
   path-is-absolute@1.0.1: {}
+
+  pathe@1.1.2: {}
+
+  pathe@2.0.3: {}
+
+  pathval@1.1.1: {}
 
   picocolors@1.1.1: {}
 
   picomatch@2.3.1: {}
+
+  pkg-types@1.3.1:
+    dependencies:
+      confbox: 0.1.8
+      mlly: 1.8.2
+      pathe: 2.0.3
 
   postcss@8.5.3:
     dependencies:
       nanoid: 3.3.9
       picocolors: 1.1.1
       source-map-js: 1.2.1
+
+  pretty-format@29.7.0:
+    dependencies:
+      '@jest/schemas': 29.6.3
+      ansi-styles: 5.2.0
+      react-is: 18.3.1
+
+  react-is@18.3.1: {}
 
   readdirp@3.6.0:
     dependencies:
@@ -978,6 +1278,8 @@ snapshots:
       mkdirp: 0.5.6
       rimraf: 2.7.1
 
+  siginfo@2.0.0: {}
+
   sorcery@0.11.1:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.0
@@ -987,15 +1289,23 @@ snapshots:
 
   source-map-js@1.2.1: {}
 
+  stackback@0.0.2: {}
+
   standardized-audio-context@25.3.77:
     dependencies:
       '@babel/runtime': 7.26.10
       automation-events: 7.1.8
       tslib: 2.8.1
 
+  std-env@3.10.0: {}
+
   strip-indent@3.0.0:
     dependencies:
       min-indent: 1.0.1
+
+  strip-literal@1.3.0:
+    dependencies:
+      acorn: 8.17.0
 
   svelte-check@3.8.6(postcss@8.5.3)(svelte@3.59.2):
     dependencies:
@@ -1047,6 +1357,12 @@ snapshots:
 
   svelte@3.59.2: {}
 
+  tinybench@2.9.0: {}
+
+  tinypool@0.7.0: {}
+
+  tinyspy@2.2.1: {}
+
   to-regex-range@5.0.1:
     dependencies:
       is-number: 7.0.0
@@ -1058,11 +1374,33 @@ snapshots:
 
   tslib@2.8.1: {}
 
+  type-detect@4.1.0: {}
+
   typescript@4.9.5: {}
 
   typescript@5.8.2: {}
 
+  ufo@1.6.4: {}
+
   undici-types@5.26.5: {}
+
+  vite-node@0.34.6(@types/node@18.19.80):
+    dependencies:
+      cac: 6.7.14
+      debug: 4.4.0
+      mlly: 1.8.2
+      pathe: 1.1.2
+      picocolors: 1.1.1
+      vite: 4.5.9(@types/node@18.19.80)
+    transitivePeerDependencies:
+      - '@types/node'
+      - less
+      - lightningcss
+      - sass
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
 
   vite@4.5.9(@types/node@18.19.80):
     dependencies:
@@ -1077,4 +1415,46 @@ snapshots:
     optionalDependencies:
       vite: 4.5.9(@types/node@18.19.80)
 
+  vitest@0.34.6:
+    dependencies:
+      '@types/chai': 4.3.20
+      '@types/chai-subset': 1.3.6(@types/chai@4.3.20)
+      '@types/node': 18.19.80
+      '@vitest/expect': 0.34.6
+      '@vitest/runner': 0.34.6
+      '@vitest/snapshot': 0.34.6
+      '@vitest/spy': 0.34.6
+      '@vitest/utils': 0.34.6
+      acorn: 8.17.0
+      acorn-walk: 8.3.5
+      cac: 6.7.14
+      chai: 4.5.0
+      debug: 4.4.0
+      local-pkg: 0.4.3
+      magic-string: 0.30.17
+      pathe: 1.1.2
+      picocolors: 1.1.1
+      std-env: 3.10.0
+      strip-literal: 1.3.0
+      tinybench: 2.9.0
+      tinypool: 0.7.0
+      vite: 4.5.9(@types/node@18.19.80)
+      vite-node: 0.34.6(@types/node@18.19.80)
+      why-is-node-running: 2.3.0
+    transitivePeerDependencies:
+      - less
+      - lightningcss
+      - sass
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
+
   wrappy@1.0.2: {}
+
+  yocto-queue@1.2.2: {}

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -37,7 +37,7 @@
       }
     ],
     "security": {
-      "csp": null
+      "csp": "default-src 'self'; img-src 'self' data: blob:; media-src 'self' data: blob:; style-src 'self' 'unsafe-inline'; script-src 'self'; connect-src 'self' blob: data:; font-src 'self' data:; worker-src 'self' blob:"
     }
   }
 }

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -25,14 +25,18 @@
           import("./lib/localDB").then(async ({ default: localDB }) => {
             const saved = await localDB.getItem("custom-backgrounds");
             if (saved) {
-              const customs = JSON.parse(saved) as Array<{ id: string; dataUrl: string }>;
-              const match   = customs.find((b) => b.id === customBgId);
-              if (match) {
-                const img  = new Image();
-                img.onload = () => {
-                  bgEl.style.backgroundImage = `url('${match.dataUrl}')`;
-                };
-                img.src = match.dataUrl;
+              try {
+                const customs = JSON.parse(saved) as Array<{ id: string; dataUrl: string }>;
+                const match   = customs.find((b) => b.id === customBgId);
+                if (match) {
+                  const img  = new Image();
+                  img.onload = () => {
+                    bgEl.style.backgroundImage = `url('${match.dataUrl}')`;
+                  };
+                  img.src = match.dataUrl;
+                }
+              } catch (err) {
+                console.error("Failed to parse saved custom backgrounds:", err);
               }
             }
           });

--- a/src/lib/Config.svelte
+++ b/src/lib/Config.svelte
@@ -3,12 +3,17 @@
  -->
 
 <script lang="ts">
+  import { onMount } from "svelte";
+
   // Disable Right Click
-  document.addEventListener(
-    "contextmenu",
-    function (e) {
+  onMount(() => {
+    const preventContextMenu = (e: Event) => {
       e.preventDefault();
-    },
-    false
-  );
+    };
+    document.addEventListener("contextmenu", preventContextMenu, false);
+
+    return () => {
+      document.removeEventListener("contextmenu", preventContextMenu, false);
+    };
+  });
 </script>

--- a/src/lib/PlayButton.svelte
+++ b/src/lib/PlayButton.svelte
@@ -11,6 +11,10 @@
   import Visualizer from "../lib/components/Visualizer/index.svelte";
   import ChordProgression from "../lib/engine/Chords/ChordProgression";
   import intervalWeights from "../lib/engine/Chords/IntervalWeights";
+  import {
+      nearestChordToneScalePos,
+      pickWeightedIndex,
+  } from "../lib/engine/Chords/melodyHelpers";
   import Keys from "../lib/engine/Chords/Keys";
   import { fiveToFive } from "../lib/engine/Chords/MajorScale";
   import Hat from "../lib/engine/Drums/Hat";
@@ -27,12 +31,26 @@
     jungle: 1,
     main_track: 1,
   };
-  // Load previous vols or defualt
-  let volumes =
-    JSON.parse(localStorage.getItem(STORAGE_KEY)) || DEFFAULT_VOLUMES;
+  // Load previous vols or default (guard against corrupt localStorage)
+  let volumes;
+  try {
+    volumes = JSON.parse(localStorage.getItem(STORAGE_KEY)) || DEFFAULT_VOLUMES;
+  } catch (e) {
+    volumes = DEFFAULT_VOLUMES;
+  }
   // Convert linear volume (0 to 1) to dB
   const linearToDb = (value) =>
     value === 0 ? -Infinity : 20 * Math.log10(value);
+
+  // Resting cutoff of the master low-pass. Transitions dip below this and must
+  // ramp back UP to it so the mix never gets permanently darker (GEN-8).
+  const MASTER_LPF_BASE_CUTOFF = 2000;
+  // Tempo / feel. NOTE: these still need listening-based tuning — they are
+  // reasonable starting points, not final values (GEN-3).
+  const BASE_BPM = 150; // lofi sits a touch lower; kept near the original 156
+  const SWING_AMOUNT = 0.5; // was 1.0 (max) — too extreme; ~0.5 is a gentler shuffle
+  // How likely a resolved melody note is pulled onto a chord tone (GEN-1).
+  const CHORD_TONE_PULL = 0.5;
 
   // Setup audio chain
   const cmp = new Tone.Compressor({
@@ -41,11 +59,11 @@
     attack: 0.5,
     release: 0.1,
   });
-  const lpf = new Tone.Filter(2000, "lowpass");
+  const lpf = new Tone.Filter(MASTER_LPF_BASE_CUTOFF, "lowpass");
   const vol = new Tone.Volume(linearToDb(volumes.main_track));
-  Tone.Master.chain(cmp, lpf, vol);
-  Tone.Transport.bpm.value = 156;
-  Tone.Transport.swing = 1;
+  Tone.getDestination().chain(cmp, lpf, vol);
+  Tone.Transport.bpm.value = BASE_BPM;
+  Tone.Transport.swing = SWING_AMOUNT;
 
   // State variables
   let key = "C";
@@ -59,7 +77,6 @@
   let snareLoaded = false;
   let hatLoaded = false;
 
-  let contextStarted = false;
   let genChordsOnce = false;
 
   let kickOff = false;
@@ -80,6 +97,8 @@
 
   // Sequences
   let chords, melody, kickLoop, snareLoop, hatLoop;
+  // Volume-poll interval id (cleared in onDestroy — PERF-2 / BUG-9)
+  let volumeInterval;
 
   onMount(() => {
     // Setup sequences
@@ -148,11 +167,21 @@
     snareLoop.humanize = true;
     hatLoop.humanize = true;
 
-    // Listen for spacebar press
+    // Listen for spacebar press. Route through handleButtonAction so the same
+    // load/generation guards the play button enforces also apply to Space
+    // (CRIT-1 — calling toggle() directly during sample load crashes/freezes).
     const handleKeydown = (e) => {
       if (e.code === "Space") {
+        const target = e.target;
+        const isTyping =
+          target &&
+          (target.tagName === "INPUT" ||
+            target.tagName === "TEXTAREA" ||
+            target.isContentEditable);
+        // Don't hijack Space while the user is typing.
+        if (isTyping) return;
         e.preventDefault();
-        toggle();
+        handleButtonAction();
       }
     };
 
@@ -179,10 +208,19 @@
   });
 
   onDestroy(() => {
+    // Stop the volume-poll interval (PERF-2).
+    if (volumeInterval) clearInterval(volumeInterval);
     if (Tone.Transport.state === "started") {
       noise.stop();
       Tone.Transport.stop();
     }
+    // Dispose the sequences so their scheduled events are released (BUG-9).
+    [chords, melody, kickLoop, snareLoop, hatLoop].forEach((seq) => {
+      if (seq) {
+        seq.stop();
+        seq.dispose();
+      }
+    });
   });
 
   let barCount = 0;
@@ -197,7 +235,11 @@
     const nextMelodyDensity = Math.random() * 0.3 + 0.2;
     const nextMelodyOff = Math.random() < 0.25;
 
-    if (progress === 4) {
+    // Section boundaries derived from the progression length (BUG-7): the
+    // midpoint refreshes drums, the start refreshes drums + melody.
+    const midpoint = Math.floor(progression.length / 2);
+
+    if (progress === midpoint) {
       progress = nextProgress;
       kickOff = nextKickOff;
       snareOff = nextSnareOff;
@@ -230,7 +272,11 @@
 
     // Change keys/chords
     generateProgression()
-    
+
+    // GEN-3: drift the tempo a few BPM per section for variety (kept subtle).
+    const bpmDrift = Math.floor(Math.random() * 7) - 3; // -3..+3
+    Tone.Transport.bpm.rampTo(BASE_BPM + bpmDrift, 2);
+
     // Original Instrument Logic (Applied in ALL active modes: MUSIC, ATMOSPHERE, WORLD)
     // This was the "current main lofi track generation"
     melodyDensity = 0.2 + Math.random() * 0.5;
@@ -263,7 +309,8 @@
     // Crossfade FX (Always apply for smoother transitions if not OFF)
     lpf.frequency.linearRampTo(300, 2) // 2s Muffle
     setTimeout(() => {
-      lpf.frequency.linearRampTo(1200, 2) // Open back up
+      // Restore the full base cutoff so the mix doesn't stay darker (GEN-8).
+      lpf.frequency.linearRampTo(MASTER_LPF_BASE_CUTOFF, 2) // Open back up
       setTimeout(() => {
         isTransitioning = false;
       }, 2000);
@@ -271,6 +318,10 @@
   }
 
   function playChord() {
+    // Defensive: nothing to play before a progression has been generated (BUG-1).
+    if (progression.length === 0 || scale.length === 0) {
+      return;
+    }
     const chord = progression[progress];
     const root = Tone.Frequency(key + "3").transpose(chord.semitoneDist);
     const size = 4;
@@ -284,6 +335,11 @@
   }
 
   function playMelody() {
+    // Defensive: nothing to walk before a scale/progression exists (BUG-1 —
+    // an empty scale used to drive the weighted picker into an infinite loop).
+    if (progression.length === 0 || scale.length === 0) {
+      return;
+    }
     if (melodyOff || !(Math.random() < melodyDensity)) {
       return;
     }
@@ -302,29 +358,30 @@
       }
     }
 
-    let weights = descend
+    const weights = descend
       ? intervalWeights.slice(0, descendRange)
       : intervalWeights.slice(0, ascendRange);
 
-    const sum = weights.reduce((prev, curr) => prev + curr, 0);
-    weights = weights.map((w) => w / sum);
-    for (let i = 1; i < weights.length; i++) {
-      weights[i] += weights[i - 1];
-    }
-
-    const randomWeight = Math.random();
-    let scaleDist = 0;
-    let found = false;
-    while (!found) {
-      if (randomWeight <= weights[scaleDist]) {
-        found = true;
-      } else {
-        scaleDist++;
-      }
+    // Bounded weighted pick: returns -1 for empty weights and never runs past
+    // the array end (BUG-1).
+    const scaleDist = pickWeightedIndex(weights, Math.random());
+    if (scaleDist < 0) {
+      return;
     }
 
     const scalePosChange = descend ? -scaleDist : scaleDist;
-    const newScalePos = scalePos + scalePosChange;
+    let newScalePos = scalePos + scalePosChange;
+
+    // GEN-1: occasionally pull the resolved note onto a chord tone of the
+    // current chord so the melody outlines the harmony (subtle + diatonic).
+    if (Math.random() < CHORD_TONE_PULL) {
+      const snapped = nearestChordToneScalePos(newScalePos, progression[progress]);
+      if (snapped >= 0) {
+        newScalePos = snapped;
+      }
+    }
+    // Keep the walk in-bounds regardless of any nudge.
+    newScalePos = Math.max(0, Math.min(scale.length - 1, newScalePos));
 
     scalePos = newScalePos;
     // @ts-ignore
@@ -368,41 +425,42 @@
     window.dispatchEvent(new CustomEvent("lofi-play-state-changed", { detail: { isPlaying } }));
   }
 
-  function startAudioContext() {
-    Tone.start();
-    contextStarted = true;
-  }
-
   $: allSamplesLoaded = pianoLoaded && kickLoaded && snareLoaded && hatLoaded;
-  $: activeProgressionIndex = (progress + 7) % 8;
+  // Highlight the chord that is currently sounding (one behind `progress`,
+  // which already points at the next chord). Derived from the actual
+  // progression length rather than a hardcoded 8 (BUG-7).
+  $: activeProgressionIndex =
+    progression.length > 0
+      ? (progress + progression.length - 1) % progression.length
+      : 0;
   // Update volume
   onMount(() => {
-    setInterval(() => {
-      let updatedVol =
-        JSON.parse(localStorage.getItem(STORAGE_KEY)) || DEFFAULT_VOLUMES;
+    volumeInterval = setInterval(() => {
+      let updatedVol;
+      try {
+        updatedVol =
+          JSON.parse(localStorage.getItem(STORAGE_KEY)) || DEFFAULT_VOLUMES;
+      } catch (e) {
+        updatedVol = DEFFAULT_VOLUMES;
+      }
       vol.volume.value = linearToDb(updatedVol.main_track);
     }, 100);
   });
-  // automically start audio context after samples are loaded
-  $: if (allSamplesLoaded && !contextStarted) {
-    startAudioContext();
+  // Generate the first progression once samples are loaded so the preview
+  // renders. The AudioContext is NOT started here — it is unlocked only from a
+  // real user gesture via toggle()'s Tone.start() (BUG-6).
+  $: if (allSamplesLoaded && !genChordsOnce) {
     generateProgression();
   }
 
   function handleButtonAction() {
     if (!allSamplesLoaded) {
-      // Do nothing, button is disabled
+      // Button is disabled until every sample has loaded.
       return;
-    } else if (!contextStarted) {
-      // Initialize audio context
-      startAudioContext();
-    } else if (!genChordsOnce) {
-      // Chords not generated yet, can't play
-      return;
-    } else {
-      // Normal play/pause functionality
-      toggle();
     }
+    // By the time samples are loaded the first progression has been generated,
+    // so play/pause is the only remaining action (BUG-6).
+    toggle();
   }
 </script>
 
@@ -415,10 +473,6 @@
     >
       {#if !allSamplesLoaded}
         <IconLoader size={30} class="spinning" />
-      {:else if !contextStarted}
-        <span class="context-text">Initialize Audio</span>
-      {:else if !genChordsOnce}
-        <IconPlayerPlayFilled size={30} class="disabled" />
       {:else if isPlaying}
         <IconPlayerPauseFilled size={30} />
       {:else}
@@ -430,21 +484,19 @@
     </button>
   </div>
 
-  {#if allSamplesLoaded && contextStarted}
-    {#if genChordsOnce}
-      <ol class="progressionList">
-        <li class="key" id="glass">{key}</li>
-        {#each progression as chord, idx}
-          <li id="glass" class={idx === activeProgressionIndex ? "live" : ""}>
-            {chord.degree}
-          </li>
-        {/each}
-      </ol>
-    {/if}
+  {#if genChordsOnce}
+    <ol class="progressionList">
+      <li class="key" id="glass">{key}</li>
+      {#each progression as chord, idx}
+        <li id="glass" class={idx === activeProgressionIndex ? "live" : ""}>
+          {chord.degree}
+        </li>
+      {/each}
+    </ol>
   {/if}
   {#if Tone.Transport.state === "started"}
     <div class="visualizer-container">
-      <Visualizer audio={Tone.Master} />
+      <Visualizer audio={Tone.getDestination()} />
     </div>
   {/if}
 </div>

--- a/src/lib/PlayButton.svelte
+++ b/src/lib/PlayButton.svelte
@@ -6,9 +6,12 @@
       IconRefresh,
   } from "@tabler/icons-svelte";
   import { onDestroy, onMount } from "svelte";
+  import { get } from "svelte/store";
 // @ts-ignore
   import * as Tone from "tone";
   import Visualizer from "../lib/components/Visualizer/index.svelte";
+  import { volumes } from "../lib/stores/volumes";
+  import { setEffect, type EffectKey } from "../lib/stores/effects";
   import ChordProgression from "../lib/engine/Chords/ChordProgression";
   import intervalWeights from "../lib/engine/Chords/IntervalWeights";
   import {
@@ -23,21 +26,6 @@
   import Snare from "../lib/engine/Drums/Snare";
   import Piano from "../lib/engine/Piano/Piano";
 
-  const STORAGE_KEY = "Volumes";
-  const DEFFAULT_VOLUMES = {
-    rain: 1,
-    thunder: 1,
-    campfire: 1,
-    jungle: 1,
-    main_track: 1,
-  };
-  // Load previous vols or default (guard against corrupt localStorage)
-  let volumes;
-  try {
-    volumes = JSON.parse(localStorage.getItem(STORAGE_KEY)) || DEFFAULT_VOLUMES;
-  } catch (e) {
-    volumes = DEFFAULT_VOLUMES;
-  }
   // Convert linear volume (0 to 1) to dB
   const linearToDb = (value) =>
     value === 0 ? -Infinity : 20 * Math.log10(value);
@@ -60,8 +48,11 @@
     release: 0.1,
   });
   const lpf = new Tone.Filter(MASTER_LPF_BASE_CUTOFF, "lowpass");
-  const vol = new Tone.Volume(linearToDb(volumes.main_track));
+  const vol = new Tone.Volume(linearToDb(get(volumes).main_track));
   Tone.getDestination().chain(cmp, lpf, vol);
+  // Keep the master volume in sync with the store (PERF-3) — replaces the old
+  // 100ms localStorage poll.
+  $: vol.volume.value = linearToDb($volumes.main_track);
   Tone.Transport.bpm.value = BASE_BPM;
   Tone.Transport.swing = SWING_AMOUNT;
 
@@ -87,6 +78,9 @@
 
   let isPlaying = false;
   let autoDJMode = "MUSIC";
+  // Effects the Auto-DJ has switched on, so it can turn off exactly what it
+  // enabled (and only that) when leaving ATMOSPHERE/WORLD (BUG-5).
+  const djEffects = new Set<EffectKey>();
 
   // Initialize instruments
   const pn = new Piano(() => (pianoLoaded = true)).sampler;
@@ -97,8 +91,6 @@
 
   // Sequences
   let chords, melody, kickLoop, snareLoop, hatLoop;
-  // Volume-poll interval id (cleared in onDestroy — PERF-2 / BUG-9)
-  let volumeInterval;
 
   onMount(() => {
     // Setup sequences
@@ -191,6 +183,12 @@
 
     const handleAutoDJModeChange = (e) => {
       autoDJMode = e.detail.mode;
+      // BUG-5: leaving the effect-driving modes turns OFF only the effects the
+      // Auto-DJ enabled, leaving any user-enabled effects untouched.
+      if (autoDJMode === "MUSIC" || autoDJMode === "MANUAL") {
+        djEffects.forEach((eff) => setEffect(eff, false));
+        djEffects.clear();
+      }
     };
 
     window.addEventListener("keydown", handleKeydown);
@@ -208,8 +206,6 @@
   });
 
   onDestroy(() => {
-    // Stop the volume-poll interval (PERF-2).
-    if (volumeInterval) clearInterval(volumeInterval);
     if (Tone.Transport.state === "started") {
       noise.stop();
       Tone.Transport.stop();
@@ -285,14 +281,21 @@
     hatOff = Math.random() < 0.22;
     melodyOff = Math.random() < 0.25;
 
-    // Smart Effects: Toggle environmental effects randomly
+    // Smart Effects: engage/disengage environmental effects via the store so the
+    // Auto-DJ tracks exactly what it turned on and never fights the user (BUG-5).
     // Applied in ATMOSPHERE and WORLD
     if (autoDJMode === "ATMOSPHERE" || autoDJMode === "WORLD") {
-      const effects = ["rain", "thunder", "jungle", "campfire"];
-      // 30% chance to toggle an effect
+      const effectKeys: EffectKey[] = ["rain", "thunder", "jungle", "campfire"];
+      // 30% chance to flip one of the Auto-DJ's own effects on/off
       if (Math.random() < 0.3) {
-        const effect = effects[Math.floor(Math.random() * effects.length)];
-        window.dispatchEvent(new CustomEvent(`lofi-toggle-${effect}`));
+        const effect = effectKeys[Math.floor(Math.random() * effectKeys.length)];
+        if (djEffects.has(effect)) {
+          setEffect(effect, false);
+          djEffects.delete(effect);
+        } else {
+          setEffect(effect, true);
+          djEffects.add(effect);
+        }
       }
     }
 
@@ -433,19 +436,6 @@
     progression.length > 0
       ? (progress + progression.length - 1) % progression.length
       : 0;
-  // Update volume
-  onMount(() => {
-    volumeInterval = setInterval(() => {
-      let updatedVol;
-      try {
-        updatedVol =
-          JSON.parse(localStorage.getItem(STORAGE_KEY)) || DEFFAULT_VOLUMES;
-      } catch (e) {
-        updatedVol = DEFFAULT_VOLUMES;
-      }
-      vol.volume.value = linearToDb(updatedVol.main_track);
-    }, 100);
-  });
   // Generate the first progression once samples are loaded so the preview
   // renders. The AudioContext is NOT started here — it is unlocked only from a
   // real user gesture via toggle()'s Tone.start() (BUG-6).

--- a/src/lib/components/ContextMenu/ContextMenu.svelte
+++ b/src/lib/components/ContextMenu/ContextMenu.svelte
@@ -11,6 +11,10 @@
     IconInfoCircle,
   } from "@tabler/icons-svelte";
   import { t } from "../../locales/store";
+  import {
+    toggleEffect as toggleEffectState,
+    type EffectKey,
+  } from "../../stores/effects";
 
   let visible = false;
   let x = 0;
@@ -53,8 +57,8 @@
     window.location.reload();
   }
 
-  function toggleEffect(effect: string) {
-    window.dispatchEvent(new CustomEvent(`lofi-toggle-${effect}`));
+  function toggleEffect(effect: EffectKey) {
+    toggleEffectState(effect);
     visible = false;
   }
 

--- a/src/lib/components/Controls/CampFire/index.svelte
+++ b/src/lib/components/Controls/CampFire/index.svelte
@@ -1,43 +1,38 @@
 <script lang="ts">
   import { IconCampfire } from "@tabler/icons-svelte";
   import { onMount, onDestroy } from "svelte";
-
-  export let volume: number;
+  import { effects, toggleEffect } from "../../../stores/effects";
+  import { volumes } from "../../../stores/volumes";
 
   let fire = new Audio("assets/engine/effects/fire.mp3");
-  let isFire = false;
-
-  function toggleFire() {
-    if (isFire) {
-      fire.pause();
-    } else {
-      fire.play().catch(() => {});
-      fire.loop = true;
-      fire.volume = volume;
-    }
-
-    isFire = !isFire;
-  }
 
   // Shortuct to toggle fire with "F" key
   function handleKeydown(e: KeyboardEvent) {
     if ((e.target as HTMLElement)?.closest("input, textarea, [contenteditable]"))
       return;
     if (e.key === "f") {
-      toggleFire();
+      toggleEffect("campfire");
     }
   }
 
-  // Keep the audio element's volume in sync with the prop
-  $: if (fire) fire.volume = volume;
+  // Drive playback from the store (single source of truth)
+  $: if (fire) {
+    if ($effects.campfire) {
+      fire.loop = true;
+      fire.play().catch(() => {});
+    } else {
+      fire.pause();
+    }
+  }
+
+  // Keep the audio element's volume in sync with the store
+  $: if (fire) fire.volume = $volumes.campfire;
 
   onMount(() => {
     window.addEventListener("keydown", handleKeydown);
-    window.addEventListener("lofi-toggle-campfire", toggleFire);
 
     return () => {
       window.removeEventListener("keydown", handleKeydown);
-      window.removeEventListener("lofi-toggle-campfire", toggleFire);
     };
   });
 
@@ -48,11 +43,11 @@
 
 <button
   style={`
-        background-color: ${isFire ? "white" : "transparent"};
+        background-color: ${$effects.campfire ? "white" : "transparent"};
         `}
-  on:click={toggleFire}
+  on:click={() => toggleEffect("campfire")}
 >
-  <IconCampfire size={25} color={isFire ? "black" : "white"} />
+  <IconCampfire size={25} color={$effects.campfire ? "black" : "white"} />
 </button>
 
 <style>

--- a/src/lib/components/Controls/CampFire/index.svelte
+++ b/src/lib/components/Controls/CampFire/index.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { IconCampfire } from "@tabler/icons-svelte";
-  import { onMount } from "svelte";
+  import { onMount, onDestroy } from "svelte";
 
   export let volume: number;
 
@@ -11,7 +11,7 @@
     if (isFire) {
       fire.pause();
     } else {
-      fire.play();
+      fire.play().catch(() => {});
       fire.loop = true;
       fire.volume = volume;
     }
@@ -20,22 +20,29 @@
   }
 
   // Shortuct to toggle fire with "F" key
-  window.addEventListener("keydown", (e) => {
+  function handleKeydown(e: KeyboardEvent) {
+    if ((e.target as HTMLElement)?.closest("input, textarea, [contenteditable]"))
+      return;
     if (e.key === "f") {
       toggleFire();
     }
-  });
+  }
 
-  // Update volume
+  // Keep the audio element's volume in sync with the prop
+  $: if (fire) fire.volume = volume;
+
   onMount(() => {
+    window.addEventListener("keydown", handleKeydown);
     window.addEventListener("lofi-toggle-campfire", toggleFire);
-    setInterval(() => {
-      fire.volume = volume;
-    },100);
 
     return () => {
+      window.removeEventListener("keydown", handleKeydown);
       window.removeEventListener("lofi-toggle-campfire", toggleFire);
     };
+  });
+
+  onDestroy(() => {
+    fire.pause();
   });
 </script>
 

--- a/src/lib/components/Controls/Jungle/index.svelte
+++ b/src/lib/components/Controls/Jungle/index.svelte
@@ -1,43 +1,38 @@
 <script lang="ts">
   import { IconTrees } from "@tabler/icons-svelte";
   import { onMount, onDestroy } from "svelte";
-
-  export let volume: number;
+  import { effects, toggleEffect } from "../../../stores/effects";
+  import { volumes } from "../../../stores/volumes";
 
   let jungle = new Audio("assets/engine/effects/jungle.mp3");
-  let isActive = false;
-
-  function toggleJungle() {
-    if (isActive) {
-      jungle.pause();
-    } else {
-      jungle.play().catch(() => {});
-      jungle.loop = true;
-      jungle.volume = volume;
-    }
-
-    isActive = !isActive;
-  }
 
   // Shortuct to toggle jungle with "D" key
   function handleKeydown(e: KeyboardEvent) {
     if ((e.target as HTMLElement)?.closest("input, textarea, [contenteditable]"))
       return;
     if (e.key === "d") {
-      toggleJungle();
+      toggleEffect("jungle");
     }
   }
 
-  // Keep the audio element's volume in sync with the prop
-  $: if (jungle) jungle.volume = volume;
+  // Drive playback from the store (single source of truth)
+  $: if (jungle) {
+    if ($effects.jungle) {
+      jungle.loop = true;
+      jungle.play().catch(() => {});
+    } else {
+      jungle.pause();
+    }
+  }
+
+  // Keep the audio element's volume in sync with the store
+  $: if (jungle) jungle.volume = $volumes.jungle;
 
   onMount(() => {
     window.addEventListener("keydown", handleKeydown);
-    window.addEventListener("lofi-toggle-jungle", toggleJungle);
 
     return () => {
       window.removeEventListener("keydown", handleKeydown);
-      window.removeEventListener("lofi-toggle-jungle", toggleJungle);
     };
   });
 
@@ -48,11 +43,11 @@
 
 <button
   style={`
-        background-color: ${isActive ? "white" : "transparent"};
+        background-color: ${$effects.jungle ? "white" : "transparent"};
         `}
-  on:click={toggleJungle}
+  on:click={() => toggleEffect("jungle")}
 >
-  <IconTrees size={25} color={isActive ? "black" : "white"} />
+  <IconTrees size={25} color={$effects.jungle ? "black" : "white"} />
 </button>
 
 <style>

--- a/src/lib/components/Controls/Jungle/index.svelte
+++ b/src/lib/components/Controls/Jungle/index.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { IconTrees } from "@tabler/icons-svelte";
-  import { onMount } from "svelte";
+  import { onMount, onDestroy } from "svelte";
 
   export let volume: number;
 
@@ -11,7 +11,7 @@
     if (isActive) {
       jungle.pause();
     } else {
-      jungle.play();
+      jungle.play().catch(() => {});
       jungle.loop = true;
       jungle.volume = volume;
     }
@@ -20,21 +20,29 @@
   }
 
   // Shortuct to toggle jungle with "D" key
-  window.addEventListener("keydown", (e) => {
+  function handleKeydown(e: KeyboardEvent) {
+    if ((e.target as HTMLElement)?.closest("input, textarea, [contenteditable]"))
+      return;
     if (e.key === "d") {
       toggleJungle();
     }
-  });
-  // Update volume
+  }
+
+  // Keep the audio element's volume in sync with the prop
+  $: if (jungle) jungle.volume = volume;
+
   onMount(() => {
+    window.addEventListener("keydown", handleKeydown);
     window.addEventListener("lofi-toggle-jungle", toggleJungle);
-    setInterval(() => {
-      jungle.volume = volume;
-    },100);
 
     return () => {
+      window.removeEventListener("keydown", handleKeydown);
       window.removeEventListener("lofi-toggle-jungle", toggleJungle);
     };
+  });
+
+  onDestroy(() => {
+    jungle.pause();
   });
 </script>
 

--- a/src/lib/components/Controls/Rain/index.svelte
+++ b/src/lib/components/Controls/Rain/index.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { IconCloudRain } from "@tabler/icons-svelte";
-  import { onMount } from "svelte";
+  import { onMount, onDestroy } from "svelte";
   import RainAnimation from "./RainAnimation.svelte";
 
   export let volume: number;
@@ -12,7 +12,7 @@
     if (isRaining) {
       rain.pause();
     } else {
-      rain.play();
+      rain.play().catch(() => {});
       rain.loop = true;
       rain.volume = volume;
     }
@@ -21,22 +21,29 @@
   }
 
   // Shortuct to toggle rain with "A" key
-  window.addEventListener("keydown", (e) => {
+  function handleKeydown(e: KeyboardEvent) {
+    if ((e.target as HTMLElement)?.closest("input, textarea, [contenteditable]"))
+      return;
     if (e.key === "a") {
       toggleRain();
     }
-  });
+  }
+
+  // Keep the audio element's volume in sync with the prop
+  $: if (rain) rain.volume = volume;
 
   onMount(() => {
+    window.addEventListener("keydown", handleKeydown);
     window.addEventListener("lofi-toggle-rain", toggleRain);
-    
-    setInterval(() => {
-      rain.volume = volume;
-    },100);
 
     return () => {
+      window.removeEventListener("keydown", handleKeydown);
       window.removeEventListener("lofi-toggle-rain", toggleRain);
     };
+  });
+
+  onDestroy(() => {
+    rain.pause();
   });
 </script>
 

--- a/src/lib/components/Controls/Rain/index.svelte
+++ b/src/lib/components/Controls/Rain/index.svelte
@@ -2,43 +2,38 @@
   import { IconCloudRain } from "@tabler/icons-svelte";
   import { onMount, onDestroy } from "svelte";
   import RainAnimation from "./RainAnimation.svelte";
-
-  export let volume: number;
+  import { effects, toggleEffect } from "../../../stores/effects";
+  import { volumes } from "../../../stores/volumes";
 
   let rain = new Audio("assets/engine/effects/rain.mp3");
-  let isRaining = false;
-
-  function toggleRain() {
-    if (isRaining) {
-      rain.pause();
-    } else {
-      rain.play().catch(() => {});
-      rain.loop = true;
-      rain.volume = volume;
-    }
-
-    isRaining = !isRaining;
-  }
 
   // Shortuct to toggle rain with "A" key
   function handleKeydown(e: KeyboardEvent) {
     if ((e.target as HTMLElement)?.closest("input, textarea, [contenteditable]"))
       return;
     if (e.key === "a") {
-      toggleRain();
+      toggleEffect("rain");
     }
   }
 
-  // Keep the audio element's volume in sync with the prop
-  $: if (rain) rain.volume = volume;
+  // Drive playback from the store (single source of truth)
+  $: if (rain) {
+    if ($effects.rain) {
+      rain.loop = true;
+      rain.play().catch(() => {});
+    } else {
+      rain.pause();
+    }
+  }
+
+  // Keep the audio element's volume in sync with the store
+  $: if (rain) rain.volume = $volumes.rain;
 
   onMount(() => {
     window.addEventListener("keydown", handleKeydown);
-    window.addEventListener("lofi-toggle-rain", toggleRain);
 
     return () => {
       window.removeEventListener("keydown", handleKeydown);
-      window.removeEventListener("lofi-toggle-rain", toggleRain);
     };
   });
 
@@ -50,13 +45,13 @@
 <div>
   <button
     style={`
-      background-color: ${isRaining ? "white" : "transparent"};
+      background-color: ${$effects.rain ? "white" : "transparent"};
       `}
-    on:click={toggleRain}
+    on:click={() => toggleEffect("rain")}
   >
-    <IconCloudRain size={25} color={isRaining ? "black" : "white"} />
+    <IconCloudRain size={25} color={$effects.rain ? "black" : "white"} />
   </button>
-  <RainAnimation {isRaining} />
+  <RainAnimation isRaining={$effects.rain} />
 </div>
 
 <style>

--- a/src/lib/components/Controls/Settings/Background.svelte
+++ b/src/lib/components/Controls/Settings/Background.svelte
@@ -79,7 +79,12 @@
   async function loadCustomBackgrounds() {
     const saved = await localDB.getItem("custom-backgrounds");
     if (saved) {
-      customBackgrounds = JSON.parse(saved);
+      try {
+        customBackgrounds = JSON.parse(saved);
+      } catch (err) {
+        console.error("Failed to parse saved custom backgrounds:", err);
+        customBackgrounds = [];
+      }
     }
   }
 

--- a/src/lib/components/Controls/Settings/Volume.svelte
+++ b/src/lib/components/Controls/Settings/Volume.svelte
@@ -1,110 +1,73 @@
 <script lang="ts">
     import { t } from "../../../locales/store";
-    const STORAGE_KEY = "Volumes";
-    const DEFFAULT_VOLUMES = {
-        rain: 1,
-        thunder: 1,
-        campfire: 1,
-        jungle: 1,
-        main_track: 1,
-    };
-    // Load previous vols or defualt
-    let volumes =
-        JSON.parse(localStorage.getItem(STORAGE_KEY)) || DEFFAULT_VOLUMES;
-
-    // Save current volumes to local storage
-    function SaveVolume() {
-        localStorage.setItem(STORAGE_KEY, JSON.stringify(volumes));
-    }
-
-    // Updater functions for each volume knob
-    function updateRainVolume(e) {
-        volumes.rain = parseFloat(e.target.value);
-        SaveVolume();
-    }
-    function updateThunderVolume(e) {
-        volumes.thunder = parseFloat(e.target.value);
-        SaveVolume();
-    }
-    function updateJungleVolume(e) {
-        volumes.jungle = parseFloat(e.target.value);
-        SaveVolume();
-    }
-    function updateFireVolume(e) {
-        volumes.campfire = parseFloat(e.target.value);
-        SaveVolume();
-    }
-    function updateMainTrackVolume(e) {
-        volumes.main_track = parseFloat(e.target.value);
-        SaveVolume();
-    }
+    import { volumes, setVolume } from "../../../stores/volumes";
 </script>
 
 <div>
     <h4>{$t.settings.volume.title}</h4>
     <section id="rain-volume">
         <h5>{$t.settings.volume.rain}</h5>
-        <p>{Math.round(volumes.rain * 100)}</p>
+        <p>{Math.round($volumes.rain * 100)}</p>
         <input
             id="volume-slider"
             type="range"
-            bind:value={volumes.rain}
+            value={$volumes.rain}
             min="0.01"
             max="1"
             step="0.01"
-            on:input={updateRainVolume}
+            on:input={(e) => setVolume("rain", parseFloat(e.currentTarget.value))}
         />
     </section>
     <section id="thunder-volume">
         <h5>{$t.settings.volume.thunder}</h5>
-        <p>{Math.round(volumes.thunder * 100)}</p>
+        <p>{Math.round($volumes.thunder * 100)}</p>
         <input
             id="volume-slider"
             type="range"
-            bind:value={volumes.thunder}
+            value={$volumes.thunder}
             min="0.01"
             max="1"
             step="0.01"
-            on:input={updateThunderVolume}
+            on:input={(e) => setVolume("thunder", parseFloat(e.currentTarget.value))}
         />
     </section>
     <section id="jungle-volume">
         <h5>{$t.settings.volume.jungle}</h5>
-        <p>{Math.round(volumes.jungle * 100)}</p>
+        <p>{Math.round($volumes.jungle * 100)}</p>
         <input
             id="volume-slider"
             type="range"
-            bind:value={volumes.jungle}
+            value={$volumes.jungle}
             min="0.01"
             max="1"
             step="0.01"
-            on:input={updateJungleVolume}
+            on:input={(e) => setVolume("jungle", parseFloat(e.currentTarget.value))}
         />
     </section>
     <section id="fire-volume">
         <h5>{$t.settings.volume.campfire}</h5>
-        <p>{Math.round(volumes.campfire * 100)}</p>
+        <p>{Math.round($volumes.campfire * 100)}</p>
         <input
             id="volume-slider"
             type="range"
-            bind:value={volumes.campfire}
+            value={$volumes.campfire}
             min="0.01"
             max="1"
             step="0.01"
-            on:input={updateFireVolume}
+            on:input={(e) => setVolume("campfire", parseFloat(e.currentTarget.value))}
         />
     </section>
     <section id="main-track-volume">
         <h5>{$t.settings.volume.main_track}</h5>
-        <p>{Math.round(volumes.main_track * 100)}</p>
+        <p>{Math.round($volumes.main_track * 100)}</p>
         <input
             id="volume-slider"
             type="range"
-            bind:value={volumes.main_track}
+            value={$volumes.main_track}
             min="0.01"
             max="1"
             step="0.01"
-            on:input={updateMainTrackVolume}
+            on:input={(e) => setVolume("main_track", parseFloat(e.currentTarget.value))}
         />
     </section>
 </div>

--- a/src/lib/components/Controls/Settings/index.svelte
+++ b/src/lib/components/Controls/Settings/index.svelte
@@ -15,20 +15,11 @@
   }
 
   // Shortuct to toggle settings with "J" key
-  window.addEventListener("keydown", (e) => {
+  function handleKeydown(e: KeyboardEvent) {
     if (e.key === "j") {
       toggle();
     }
-  });
-
-  // when mounted toggle settings
-  // to excute settings of children (old saved)
-  onMount(() => {
-    toggle();
-    setTimeout(() => {
-      toggle();
-    }, 10);
-  });
+  }
 
   const handleClickOutside = (event: MouseEvent) => {
     if (
@@ -39,7 +30,18 @@
       isActive = false;
     }
   };
-  document.addEventListener("click", handleClickOutside);
+
+  // Saved child settings are applied without opening the panel:
+  // Background by App.svelte (and Background's own onMount), Volume via the
+  // localStorage-polled volume sync, and AutoDJ on its first interaction.
+  onMount(() => {
+    window.addEventListener("keydown", handleKeydown);
+    document.addEventListener("click", handleClickOutside);
+    return () => {
+      window.removeEventListener("keydown", handleKeydown);
+      document.removeEventListener("click", handleClickOutside);
+    };
+  });
 
   const languages = [
     { code: "en", label: "English" },

--- a/src/lib/components/Controls/Thunder/index.svelte
+++ b/src/lib/components/Controls/Thunder/index.svelte
@@ -1,43 +1,38 @@
 <script lang="ts">
   import { IconCloudStorm } from "@tabler/icons-svelte";
   import { onMount, onDestroy } from "svelte";
-
-  export let volume: number;
+  import { effects, toggleEffect } from "../../../stores/effects";
+  import { volumes } from "../../../stores/volumes";
 
   let storm = new Audio("assets/engine/effects/thunder.mp3");
-  let isStorming = false;
-
-  function toggleThunder() {
-    if (isStorming) {
-      storm.pause();
-    } else {
-      storm.play().catch(() => {});
-      storm.loop = true;
-      storm.volume = volume;
-    }
-
-    isStorming = !isStorming;
-  }
 
   // Shortuct to toggle storm with "S" key
   function handleKeydown(e: KeyboardEvent) {
     if ((e.target as HTMLElement)?.closest("input, textarea, [contenteditable]"))
       return;
     if (e.key === "s") {
-      toggleThunder();
+      toggleEffect("thunder");
     }
   }
 
-  // Keep the audio element's volume in sync with the prop
-  $: if (storm) storm.volume = volume;
+  // Drive playback from the store (single source of truth)
+  $: if (storm) {
+    if ($effects.thunder) {
+      storm.loop = true;
+      storm.play().catch(() => {});
+    } else {
+      storm.pause();
+    }
+  }
+
+  // Keep the audio element's volume in sync with the store
+  $: if (storm) storm.volume = $volumes.thunder;
 
   onMount(() => {
     window.addEventListener("keydown", handleKeydown);
-    window.addEventListener("lofi-toggle-thunder", toggleThunder);
 
     return () => {
       window.removeEventListener("keydown", handleKeydown);
-      window.removeEventListener("lofi-toggle-thunder", toggleThunder);
     };
   });
 
@@ -48,11 +43,11 @@
 
 <button
   style={`
-    background-color: ${isStorming ? "white" : "transparent"};
+    background-color: ${$effects.thunder ? "white" : "transparent"};
     `}
-  on:click={toggleThunder}
+  on:click={() => toggleEffect("thunder")}
 >
-  <IconCloudStorm size={25} color={isStorming ? "black" : "white"} />
+  <IconCloudStorm size={25} color={$effects.thunder ? "black" : "white"} />
 </button>
 
 <style>

--- a/src/lib/components/Controls/Thunder/index.svelte
+++ b/src/lib/components/Controls/Thunder/index.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { IconCloudStorm } from "@tabler/icons-svelte";
-  import { onMount } from "svelte";
+  import { onMount, onDestroy } from "svelte";
 
   export let volume: number;
 
@@ -11,7 +11,7 @@
     if (isStorming) {
       storm.pause();
     } else {
-      storm.play();
+      storm.play().catch(() => {});
       storm.loop = true;
       storm.volume = volume;
     }
@@ -20,22 +20,29 @@
   }
 
   // Shortuct to toggle storm with "S" key
-  window.addEventListener("keydown", (e) => {
+  function handleKeydown(e: KeyboardEvent) {
+    if ((e.target as HTMLElement)?.closest("input, textarea, [contenteditable]"))
+      return;
     if (e.key === "s") {
       toggleThunder();
     }
-  });
+  }
 
-  // Update volume
+  // Keep the audio element's volume in sync with the prop
+  $: if (storm) storm.volume = volume;
+
   onMount(() => {
+    window.addEventListener("keydown", handleKeydown);
     window.addEventListener("lofi-toggle-thunder", toggleThunder);
-    setInterval(() => {
-      storm.volume = volume;
-    }, 100);
 
     return () => {
+      window.removeEventListener("keydown", handleKeydown);
       window.removeEventListener("lofi-toggle-thunder", toggleThunder);
     };
+  });
+
+  onDestroy(() => {
+    storm.pause();
   });
 </script>
 

--- a/src/lib/components/Controls/index.svelte
+++ b/src/lib/components/Controls/index.svelte
@@ -4,31 +4,13 @@
   import Rain from "./Rain/index.svelte";
   import Settings from "./Settings/index.svelte";
   import Thunder from "./Thunder/index.svelte";
-
-  const STORAGE_KEY = "Volumes";
-  const DEFFAULT_VOLUMES = {
-    rain: 1,
-    thunder: 1,
-    campfire: 1,
-    jungle: 1,
-    main_track: 1,
-  };
-  // Load previous vols or defualt
-  let volumes =
-    JSON.parse(localStorage.getItem(STORAGE_KEY)) || DEFFAULT_VOLUMES;
-
-  // Update
-  setInterval(() => {
-    volumes = volumes =
-      JSON.parse(localStorage.getItem(STORAGE_KEY)) || DEFFAULT_VOLUMES;
-  }, 200);
 </script>
 
 <div class="controls glass">
-  <Rain volume={volumes.rain} />
-  <Thunder volume={volumes.thunder} />
-  <Jungle volume={volumes.jungle} />
-  <CampFire volume={volumes.campfire} />
+  <Rain />
+  <Thunder />
+  <Jungle />
+  <CampFire />
   <Settings />
 </div>
 

--- a/src/lib/components/InfoBox/Info.svelte
+++ b/src/lib/components/InfoBox/Info.svelte
@@ -17,16 +17,12 @@
     localStorage.setItem("shownBefore-info", "true");
   }
 
-  // Listen to escape key to close info box
-  document.addEventListener(
-    "keydown",
-    function (e) {
-      if (e.key === "Escape" && visible) {
-        toggleInfoBox();
-      }
-    },
-    false,
-  );
+  // Escape key toggles the info box (show + hide)
+  function handleKeydown(e: KeyboardEvent) {
+    if (e.key === "Escape") {
+      toggleInfoBox();
+    }
+  }
 
   function showNextTime() {
     localStorage.removeItem("shownBefore-info");
@@ -34,8 +30,10 @@
 
   onMount(() => {
     window.addEventListener("lofi-toggle-info", toggleInfoBox);
+    document.addEventListener("keydown", handleKeydown);
     return () => {
       window.removeEventListener("lofi-toggle-info", toggleInfoBox);
+      document.removeEventListener("keydown", handleKeydown);
     };
   });
 </script>

--- a/src/lib/components/InfoBox/SocialLinks.svelte
+++ b/src/lib/components/InfoBox/SocialLinks.svelte
@@ -18,7 +18,7 @@
   <a href="https://LofiEngine.com" target="_blank">
     <IconLink size={25} />
   </a> -->
-  <a href="https://github.com/meel-hd/lofi-engine" target="_blank">
+  <a href="https://github.com/meel-hd/lofi-engine" target="_blank" rel="noopener noreferrer">
     <IconBrandGithub size={25} />
   </a>
 </div>

--- a/src/lib/components/Tooltip.svelte
+++ b/src/lib/components/Tooltip.svelte
@@ -59,29 +59,27 @@
     targetElement = null;
   }
 
+  function handleMouseOut(e: MouseEvent) {
+    // Only hide if we mouse out of the target
+    const target = (e.target as HTMLElement).closest("[data-tooltip]");
+    if (target) {
+      // Check if we moved to a child? No, mouseout bubbles.
+      // Simpler: just check if relatedTarget is not inside the target
+      if (!target.contains(e.relatedTarget as Node)) {
+        hide();
+      }
+    }
+  }
+
   onMount(() => {
     window.addEventListener("mouseover", show);
-    window.addEventListener("mouseout", (e) => {
-      // Only hide if we mouse out of the target
-      const target = (e.target as HTMLElement).closest("[data-tooltip]");
-      if (target) {
-         // Check if we moved to a child? No, mouseout bubbles.
-         // Simpler: just check if relatedTarget is not inside the target
-         if (!target.contains(e.relatedTarget as Node)) {
-             hide();
-         }
-      }
-    });
-    
-    // Also hide on click usually? Or keep it?
-    // Let's keep it simple.
-    
+    window.addEventListener("mouseout", handleMouseOut);
     window.addEventListener("scroll", updatePosition, true); // Capture scroll to update pos
     window.addEventListener("resize", updatePosition);
 
     return () => {
       window.removeEventListener("mouseover", show);
-      window.removeEventListener("mouseout", hide); // Fix listener removal
+      window.removeEventListener("mouseout", handleMouseOut);
       window.removeEventListener("scroll", updatePosition, true);
       window.removeEventListener("resize", updatePosition);
     };

--- a/src/lib/components/TopBar/GenericControls.svelte
+++ b/src/lib/components/TopBar/GenericControls.svelte
@@ -7,41 +7,56 @@
   export let appWindow;
   export let noSideEffect = false;
 
+  let pollInterval: ReturnType<typeof setInterval>;
+
   onMount(() => {
     const close = document.getElementById("close-maximaze-wl");
     const minimize = document.getElementById("minimize-wl");
     const maximize = document.getElementById("maximaze-wl");
 
-    close.addEventListener("click", () => {
+    const handleClose = () => {
       appWindow.close();
-    });
+    };
 
-    minimize.addEventListener("click", () => {
+    const handleMinimize = () => {
       appWindow.minimize();
-    });
+    };
 
-    maximize.addEventListener("click", () => {
+    const handleMaximize = () => {
       if (isMaximized) {
         appWindow.unmaximize();
       } else {
         appWindow.maximize();
       }
       isMaximized = !isMaximized;
-    });
+    };
+
+    close.addEventListener("click", handleClose);
+    minimize.addEventListener("click", handleMinimize);
+    maximize.addEventListener("click", handleMaximize);
 
     // watch if window is maximized
     // from other sources apart from top bar
-    !noSideEffect && setInterval(() => {
-      appWindow.isMaximized().then((maximized) => {
-        isMaximized = maximized;
-        // Remove the rounded corners when maximized
-        if (isMaximized) {
-          document.body.style.borderRadius = "0px";
-        } else {
-          document.body.style.borderRadius = "10px";
-        }
-      });
-    }, 300);
+    if (!noSideEffect) {
+      pollInterval = setInterval(() => {
+        appWindow.isMaximized().then((maximized) => {
+          isMaximized = maximized;
+          // Remove the rounded corners when maximized
+          if (isMaximized) {
+            document.body.style.borderRadius = "0px";
+          } else {
+            document.body.style.borderRadius = "10px";
+          }
+        });
+      }, 300);
+    }
+
+    return () => {
+      close.removeEventListener("click", handleClose);
+      minimize.removeEventListener("click", handleMinimize);
+      maximize.removeEventListener("click", handleMaximize);
+      if (pollInterval) clearInterval(pollInterval);
+    };
   });
 </script>
 

--- a/src/lib/components/TopBar/MacControls.svelte
+++ b/src/lib/components/TopBar/MacControls.svelte
@@ -5,20 +5,22 @@
   export let appWindow;
   export let noSideEffect = false;
 
+  let pollInterval: ReturnType<typeof setInterval>;
+
   onMount(() => {
     const close = document.getElementById("close-mac");
     const minimize = document.getElementById("minimize-mac");
     const maximize = document.getElementById("maximize-mac");
 
-    close.addEventListener("click", () => {
+    const handleClose = () => {
       appWindow.close();
-    });
+    };
 
-    minimize.addEventListener("click", () => {
+    const handleMinimize = () => {
       appWindow.minimize();
-    });
+    };
 
-    maximize.addEventListener("click", () => {
+    const handleMaximize = () => {
       if (isMaximized) {
         appWindow.unmaximize();
         isMaximized = false;
@@ -26,21 +28,34 @@
         appWindow.maximize();
         isMaximized = true;
       }
-    });
+    };
+
+    close.addEventListener("click", handleClose);
+    minimize.addEventListener("click", handleMinimize);
+    maximize.addEventListener("click", handleMaximize);
 
     // watch if window is maximized
     // from other sources apart from top bar
-    !noSideEffect && setInterval(() => {
-      appWindow.isMaximized().then((maximized) => {
-        isMaximized = maximized;
-        // Remove the rounded corners when maximized
-        if (isMaximized) {
-          document.body.style.borderRadius = "0px";
-        } else {
-          document.body.style.borderRadius = "10px";
-        }
-      });
-    }, 300);
+    if (!noSideEffect) {
+      pollInterval = setInterval(() => {
+        appWindow.isMaximized().then((maximized) => {
+          isMaximized = maximized;
+          // Remove the rounded corners when maximized
+          if (isMaximized) {
+            document.body.style.borderRadius = "0px";
+          } else {
+            document.body.style.borderRadius = "10px";
+          }
+        });
+      }, 300);
+    }
+
+    return () => {
+      close.removeEventListener("click", handleClose);
+      minimize.removeEventListener("click", handleMinimize);
+      maximize.removeEventListener("click", handleMaximize);
+      if (pollInterval) clearInterval(pollInterval);
+    };
   });
 </script>
 

--- a/src/lib/components/TrackList/TrackListItem.svelte
+++ b/src/lib/components/TrackList/TrackListItem.svelte
@@ -3,6 +3,7 @@
   import { t } from "../../locales/store";
 
   export let setMeVisible;
+  export let onToggle;
   export let activeAudios = [];
   export let track = {
     id: -1,
@@ -33,8 +34,8 @@
   }
 
   function handleVolumeChange(event) {
-    volume = event.target.value;
-    localStorage.setItem("audioVolume", volume.toString());
+    volume = Number(event.target.value);
+    localStorage.setItem(`audioVolume:${track.id}`, volume.toString());
     activeAudios.forEach((item) => {
       if (item.id === track.id) {
         item.audio.volume = volume;
@@ -42,32 +43,10 @@
     });
   }
 
-  function playTrack() {
-    const audio = new Audio(`assets/engine/tracks/${track.track}`);
-    audio.volume = volume;
-    audio.play();
-    audio.loop = true;
-    activeAudios.push({
-      id: track.id,
-      audio,
-    });
-    track.isPlaying = true;
-    setMeVisible(track.id);
-  }
-
-  function pauseTrack() {
-    activeAudios.forEach((item) => {
-      if (item.id === track.id) {
-        item.audio.pause();
-      }
-    });
-    track.isPlaying = false;
-  }
-
   onMount(() => {
-    const savedVolume = localStorage.getItem("audioVolume");
+    const savedVolume = localStorage.getItem(`audioVolume:${track.id}`);
     if (savedVolume !== null) {
-      volume = parseFloat(savedVolume);
+      volume = Number(savedVolume);
     }
   });
 
@@ -82,9 +61,7 @@
       setMeVisible(track.id);
     }
   }}
-  on:click={() => {
-    track.isPlaying ? pauseTrack() : playTrack();
-  }}
+  on:click={() => onToggle(track.id)}
   class={"carousel__item " + trackItemAnimationClass}
 >
   <div
@@ -97,7 +74,7 @@
     />
     <div>
       <p id="title">Track {track.id}</p>
-      <p id="info">{$t.tracks[track.id].quote}</p>
+      <p id="info">{$t.tracks[track.id]?.quote}</p>
       {#if track.isPlaying}
         <input
           type="range"

--- a/src/lib/components/TrackList/index.svelte
+++ b/src/lib/components/TrackList/index.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { IconChevronDown } from "@tabler/icons-svelte";
   import TrackListItem from "./TrackListItem.svelte";
-  import { onMount } from "svelte";
+  import { onMount, onDestroy } from "svelte";
 
   let tracks = [
     {
@@ -54,65 +54,8 @@
   let activeAudios = [];
   let isMobileHidden = false; // Used to hide track list on mobile due to tight space
 
-  // Shortcut for stoping all effects with "k" key
-  window.addEventListener("keydown", (e) => {
-    if (e.key === "k") {
-      activeAudios.forEach((item) => {
-        item.audio.pause();
-      });
-      console.log("activeAudios", activeAudios);
-      activeAudios = [];
-      tracks.forEach((track) => {
-        track.isPlaying = false;
-      });
-    }
-  });
-
-  // Add toggle for each track with number keys
-  //  through (1-9) on keyboard
-  for (let i = 1; i < 10; i++) {
-    window.addEventListener("keydown", (e) => {
-      if (e.key === i.toString()) {
-        tracks[i - 1].isPlaying = !tracks[i - 1].isPlaying;
-        if (tracks[i - 1].isPlaying) {
-          const audio = new Audio(
-            `assets/engine/tracks/${tracks[i - 1].track}`,
-          );
-          audio.play();
-          audio.loop = true;
-          activeAudios.push({
-            id: tracks[i - 1].id,
-            audio,
-          });
-          visibleTrackId = i;
-        } else {
-          activeAudios.forEach((item) => {
-            if (item.id === tracks[i - 1].id) {
-              item.audio.pause();
-              // Remove from activeAudios
-              activeAudios = activeAudios.filter(
-                (item) => item.id !== tracks[i - 1].id,
-              );
-            }
-          });
-        }
-      }
-    });
-  }
-
   // Visible tracks animation
   let visibleTrackId = 1;
-  window.addEventListener("keydown", (e) => {
-    // Ignore change when event is targeting inputs
-    if (e.target instanceof HTMLElement && !e.target.closest("input")) {
-      if (e.key == "ArrowUp") {
-        prevTrack();
-      }
-      if (e.key == "ArrowDown") {
-        nextTrack();
-      }
-    }
-  });
 
   function nextTrack() {
     visibleTrackId < 9 ? visibleTrackId++ : (visibleTrackId = 1);
@@ -137,29 +80,80 @@
     }
   }
 
-  function toggleTrack(id: number) {
-    tracks[id - 1].isPlaying = !tracks[id - 1].isPlaying;
-    if (tracks[id - 1].isPlaying) {
-      const audio = new Audio(`assets/engine/tracks/${tracks[id - 1].track}`);
-      audio.play();
-      audio.loop = true;
-      activeAudios.push({
-        id: tracks[id - 1].id,
-        audio,
-      });
+  function getSavedVolume(id) {
+    const saved = localStorage.getItem(`audioVolume:${id}`);
+    return saved !== null ? Number(saved) : 0.5;
+  }
+
+  // Single source of truth for starting/stopping a track's audio.
+  // All control paths (click, number keys, "k", Auto-DJ) funnel through here.
+  function setTrack(id, shouldPlay) {
+    const track = tracks[id - 1];
+    if (!track) return;
+    if (shouldPlay) {
+      // Never create a second Audio for a track that is already playing
+      if (!activeAudios.some((item) => item.id === id)) {
+        const audio = new Audio(`assets/engine/tracks/${track.track}`);
+        audio.loop = true;
+        audio.volume = getSavedVolume(id);
+        audio.play().catch(() => {});
+        activeAudios.push({ id, audio });
+      }
+      track.isPlaying = true;
       visibleTrackId = id;
     } else {
       activeAudios.forEach((item) => {
-        if (item.id === tracks[id - 1].id) {
+        if (item.id === id) {
           item.audio.pause();
-          // Remove from activeAudios
-          activeAudios = activeAudios.filter(
-            (item) => item.id !== tracks[id - 1].id,
-          );
         }
       });
+      // Remove the entry so it can't leak (single source of truth)
+      activeAudios = activeAudios.filter((item) => item.id !== id);
+      track.isPlaying = false;
     }
+    activeAudios = activeAudios; // Keep parent + children sharing one reference
     tracks = tracks; // Trigger reactivity
+  }
+
+  function toggleTrack(id) {
+    setTrack(id, !tracks[id - 1].isPlaying);
+  }
+
+  function stopAllTracks() {
+    activeAudios.forEach((item) => item.audio.pause());
+    activeAudios = [];
+    tracks.forEach((track) => (track.isPlaying = false));
+    tracks = tracks; // Trigger reactivity
+  }
+
+  // Ignore shortcuts while typing in inputs/textareas/contenteditable
+  function isTypingTarget(target) {
+    return (
+      target instanceof HTMLElement &&
+      (target.closest("input, textarea") !== null || target.isContentEditable)
+    );
+  }
+
+  function handleKeydown(e) {
+    if (isTypingTarget(e.target)) return;
+
+    if (e.key === "k") {
+      stopAllTracks();
+      return;
+    }
+    if (e.key === "ArrowUp") {
+      prevTrack();
+      return;
+    }
+    if (e.key === "ArrowDown") {
+      nextTrack();
+      return;
+    }
+    // Toggle a track with the number keys (1-9)
+    const trackNumber = Number(e.key);
+    if (Number.isInteger(trackNumber) && trackNumber >= 1 && trackNumber <= 9) {
+      toggleTrack(trackNumber);
+    }
   }
 
   onMount(() => {
@@ -173,11 +167,19 @@
         isMobileHidden = e.detail.isActive;
       }
     };
+    window.addEventListener("keydown", handleKeydown);
     window.addEventListener("lofi-toggle-track", handleToggleTrack);
     window.addEventListener("settings-open-changed", handleSettingsOpen);
     return () => {
+      window.removeEventListener("keydown", handleKeydown);
       window.removeEventListener("lofi-toggle-track", handleToggleTrack);
+      window.removeEventListener("settings-open-changed", handleSettingsOpen);
     };
+  });
+
+  onDestroy(() => {
+    activeAudios.forEach((item) => item.audio.pause());
+    activeAudios = [];
   });
 </script>
 
@@ -192,6 +194,7 @@
           {activeAudios}
           {track}
           {visibleTrackId}
+          onToggle={toggleTrack}
           setMeVisible={(id) => (visibleTrackId = id)}
         />
       {/each}

--- a/src/lib/engine/Chords/Chord.test.ts
+++ b/src/lib/engine/Chords/Chord.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from "vitest";
+import Chords from "./Chords";
+
+describe("Chord.generateVoicing", () => {
+  it("produces a voicing of the requested size starting at the root", () => {
+    for (const chord of Chords) {
+      const voicing = chord.generateVoicing(4);
+      expect(voicing).toHaveLength(4);
+      expect(voicing[0]).toBe(0);
+    }
+  });
+
+  it("ascends (non-decreasing) and contains no NaN", () => {
+    // Shuffle is random, so sample many voicings per chord.
+    for (let run = 0; run < 200; run++) {
+      for (const chord of Chords) {
+        const voicing = chord.generateVoicing(4);
+        for (let i = 0; i < voicing.length; i++) {
+          expect(Number.isNaN(voicing[i])).toBe(false);
+          if (i > 0) {
+            expect(voicing[i]).toBeGreaterThanOrEqual(voicing[i - 1]);
+          }
+        }
+      }
+    }
+  });
+
+  it("returns a sane minimal voicing for size < 3", () => {
+    for (const chord of Chords) {
+      const voicing = chord.generateVoicing(2);
+      expect(voicing[0]).toBe(0);
+      expect(voicing.length).toBeGreaterThanOrEqual(1);
+      voicing.forEach((n) => expect(Number.isNaN(n)).toBe(false));
+    }
+  });
+});

--- a/src/lib/engine/Chords/Chord.ts
+++ b/src/lib/engine/Chords/Chord.ts
@@ -1,27 +1,16 @@
 import { singleOct } from './MajorScale';
 
 class Chord {
+    degree: number;
+    semitoneDist: number;
+    intervals: number[];
+    nextChordIdxs: number[];
+
     constructor(degree,intervals,nextChordIdxs) {
         this.degree = degree;
         this.semitoneDist = singleOct[degree-1];
         this.intervals = intervals;
         this.nextChordIdxs = nextChordIdxs;
-    }
-    
-    degree() {
-    	return this.degree;
-    }
-
-    semitoneDist() {
-        return this.semitoneDist;
-    }
-
-    intervals() {
-        return this.intervals;
-    }
-
-    nextChordIdxs() {
-        return this.nextChordIdxs;
     }
 
     nextChordIdx() {
@@ -29,10 +18,17 @@ class Chord {
     }
 
     generateVoicing(size) {
-        if(size<3)
-            return this.intervals.slice(0,3);
+        // Upper voices above the root (intervals[0] is the root at 0). For
+        // size < 3 this still yields a sane minimal voicing (root + whatever
+        // upper voices fit), so no special-casing is needed.
         let voicing = this.intervals.slice(1,size);
-        voicing.sort(() => Math.random()-0.5);
+        // Fisher–Yates shuffle: an unbiased randomization of the spread
+        // (sort(() => Math.random()-0.5) is non-uniform).
+        for(let i = voicing.length-1; i > 0; i--) {
+            const j = Math.floor(Math.random()*(i+1));
+            [voicing[i], voicing[j]] = [voicing[j], voicing[i]];
+        }
+        // Stack each voice above the previous so the voicing ascends.
         for(let i = 1; i<voicing.length; i++) {
             while(voicing[i] < voicing[i-1]){
                 voicing[i] += 12;
@@ -40,15 +36,6 @@ class Chord {
         }
         voicing.unshift(0);
         return voicing;
-    }
-
-    generateMode() {
-        return this.intervals.map(n => {
-            if(n>=12)
-                return n-12;
-            else
-                return n;
-        });
     }
 }
 

--- a/src/lib/engine/Chords/ChordProgression.test.ts
+++ b/src/lib/engine/Chords/ChordProgression.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from "vitest";
+import ChordProgression from "./ChordProgression";
+
+describe("ChordProgression.generate", () => {
+  it("returns null for lengths below 2", () => {
+    expect(ChordProgression.generate(1)).toBeNull();
+    expect(ChordProgression.generate(0)).toBeNull();
+  });
+
+  it("produces a progression of the requested length", () => {
+    for (const length of [2, 4, 8, 16]) {
+      const prog = ChordProgression.generate(length);
+      expect(prog).toHaveLength(length);
+    }
+  });
+
+  it("only contains valid scale degrees (1-7)", () => {
+    const prog = ChordProgression.generate(32);
+    for (const chord of prog) {
+      expect(chord.degree).toBeGreaterThanOrEqual(1);
+      expect(chord.degree).toBeLessThanOrEqual(7);
+    }
+  });
+
+  it("only uses valid chord-to-chord transitions", () => {
+    // Generation is random, so sample many progressions.
+    for (let run = 0; run < 300; run++) {
+      const prog = ChordProgression.generate(12);
+      for (let i = 0; i < prog.length - 1; i++) {
+        const current = prog[i];
+        const nextDegreeIdx = prog[i + 1].degree - 1;
+        // The next chord must be a permitted successor of the current one.
+        expect(current.nextChordIdxs).toContain(nextDegreeIdx);
+      }
+    }
+  });
+
+  it("tends to resolve on a tonic (I) at the end (cadence bias)", () => {
+    // GEN-6: the final transitions are steered toward V -> I when reachable,
+    // so the progression should usually end on the tonic — far above the ~1/7
+    // rate of a uniform random walk.
+    let tonicEndings = 0;
+    const runs = 400;
+    for (let r = 0; r < runs; r++) {
+      const prog = ChordProgression.generate(8);
+      if (prog[prog.length - 1].degree === 1) tonicEndings++;
+    }
+    expect(tonicEndings).toBeGreaterThan(runs * 0.5);
+  });
+});

--- a/src/lib/engine/Chords/ChordProgression.ts
+++ b/src/lib/engine/Chords/ChordProgression.ts
@@ -1,6 +1,22 @@
 import Chords from './Chords';
 import Chord from './Chord';
 
+const TONIC_IDX = 0; // I
+// Cadence targets in priority order for each of the final steps.
+const DOMINANTS = [4, 6];        // V, then vii° (both resolve to I)
+const PREDOMINANTS = [1, 3, 5];  // ii, IV, vi (set up the dominant)
+
+// Pick the first target that is a *valid* next chord, otherwise fall back to
+// the normal random transition. This biases toward a cadence without ever
+// producing an invalid chord-to-chord move.
+function preferTransitions(chord, targetIdxs) {
+    for(const target of targetIdxs) {
+        if(chord.nextChordIdxs.includes(target))
+            return target;
+    }
+    return chord.nextChordIdx();
+}
+
 class ChordProgression {
     static generate(length) {
         if(length < 2)
@@ -8,15 +24,30 @@ class ChordProgression {
 
         const progression = [];
         let chord = Chords[Math.floor(Math.random()*Chords.length)];
-        
+
         for(let i = 0; i < length; i++) {
             progression.push(new Chord(
                 chord.degree,
                 [...chord.intervals],
                 [...chord.nextChordIdxs]));
-            chord = Chords[chord.nextChordIdx()];
+
+            // GEN-6: steer the final few transitions toward a predominant ->
+            // dominant -> tonic cadence so the phrase tends to resolve, while
+            // only ever choosing a valid next chord (preferTransitions falls
+            // back to a random valid move when the target isn't reachable).
+            let nextIdx;
+            if(i === length - 2) {
+                nextIdx = preferTransitions(chord, [TONIC_IDX]); // resolve to I
+            } else if(i === length - 3) {
+                nextIdx = preferTransitions(chord, DOMINANTS);   // set up the V
+            } else if(i === length - 4) {
+                nextIdx = preferTransitions(chord, PREDOMINANTS); // pre-dominant
+            } else {
+                nextIdx = chord.nextChordIdx();
+            }
+            chord = Chords[nextIdx];
         }
-        
+
         return progression;
     }
 }

--- a/src/lib/engine/Chords/melodyHelpers.test.ts
+++ b/src/lib/engine/Chords/melodyHelpers.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect } from "vitest";
+import {
+  chordTonePitchClasses,
+  nearestChordToneScalePos,
+  pickWeightedIndex,
+} from "./melodyHelpers";
+import Chords from "./Chords";
+
+describe("pickWeightedIndex (locks in BUG-1)", () => {
+  it("returns -1 for an empty weight array instead of looping forever", () => {
+    // An empty scale produced empty weights -> the old while(!found) loop hung.
+    expect(pickWeightedIndex([], 0.5)).toBe(-1);
+  });
+
+  it("always returns an in-bounds index for normal weight arrays", () => {
+    const weights = [0.1, 0.3, 0.2, 0.15, 0.15, 0.025, 0.025, 0.05];
+    for (let i = 0; i <= 100; i++) {
+      const r = i / 100; // covers 0..1 inclusive
+      const idx = pickWeightedIndex(weights, r);
+      expect(idx).toBeGreaterThanOrEqual(0);
+      expect(idx).toBeLessThan(weights.length);
+    }
+  });
+
+  it("uses the final bucket as a fallback for r >= last cumulative weight", () => {
+    const weights = [0.5, 0.5];
+    expect(pickWeightedIndex(weights, 1)).toBe(weights.length - 1);
+    // Even an impossible value above 1 stays in-bounds (never overflows).
+    expect(pickWeightedIndex(weights, 2)).toBe(weights.length - 1);
+  });
+
+  it("stays in-bounds for all-zero weights (NaN-safe)", () => {
+    const idx = pickWeightedIndex([0, 0, 0], 0.5);
+    expect(idx).toBeGreaterThanOrEqual(0);
+    expect(idx).toBeLessThan(3);
+  });
+
+  it("selects the first bucket for the smallest random value", () => {
+    expect(pickWeightedIndex([0.5, 0.5], 0)).toBe(0);
+  });
+});
+
+describe("chordTonePitchClasses", () => {
+  it("includes the chord's root pitch class", () => {
+    const V = Chords[4];
+    // V's root sits 7 semitones above the tonic.
+    expect(chordTonePitchClasses(V).has(7)).toBe(true);
+  });
+});
+
+describe("nearestChordToneScalePos", () => {
+  it("keeps a position that is already a chord tone", () => {
+    const I = Chords[0];
+    // fiveToFive index 3 == offset 0 == tonic, a chord tone of I.
+    expect(nearestChordToneScalePos(3, I)).toBe(3);
+  });
+
+  it("returns -1 when no chord is given", () => {
+    expect(nearestChordToneScalePos(3, null)).toBe(-1);
+  });
+
+  it("never returns an out-of-scale index", () => {
+    const V = Chords[4];
+    for (let pos = 0; pos < 15; pos++) {
+      const snapped = nearestChordToneScalePos(pos, V);
+      if (snapped !== -1) {
+        expect(snapped).toBeGreaterThanOrEqual(0);
+        expect(snapped).toBeLessThan(15);
+      }
+    }
+  });
+});

--- a/src/lib/engine/Chords/melodyHelpers.ts
+++ b/src/lib/engine/Chords/melodyHelpers.ts
@@ -1,0 +1,61 @@
+import { fiveToFive } from './MajorScale';
+
+const mod12 = (n) => ((n % 12) + 12) % 12;
+
+/**
+ * Pick an index from a list of (relative) weights using a random value in
+ * [0, 1). Returns -1 for an empty list and is otherwise always within
+ * [0, weights.length - 1] — the final bucket acts as a fallback so the search
+ * can never run past the end of the array. This is the bounded, pure version
+ * of PlayButton's melody weighted-picker and locks in the fix for BUG-1
+ * (an empty `scale` used to yield empty `weights` and an infinite loop).
+ */
+export function pickWeightedIndex(weights, randomValue) {
+    if(weights.length === 0)
+        return -1;
+    const sum = weights.reduce((prev, curr) => prev + curr, 0);
+    let cumulative = 0;
+    for(let i = 0; i < weights.length - 1; i++) {
+        cumulative += weights[i] / sum;
+        if(randomValue <= cumulative)
+            return i;
+    }
+    // Last bucket is the fallback (also covers sum === 0 -> NaN comparisons).
+    return weights.length - 1;
+}
+
+/**
+ * Pitch classes (0-11, relative to the tonic) of a chord's tones, derived from
+ * its root offset within the key plus each chord interval.
+ */
+export function chordTonePitchClasses(chord) {
+    const set = new Set();
+    for(const interval of chord.intervals) {
+        set.add(mod12(chord.semitoneDist + interval));
+    }
+    return set;
+}
+
+/**
+ * Given a target scale position (index into `fiveToFive`), return the nearest
+ * scale position whose pitch class is a chord tone of `chord`, searching no
+ * further than `maxStep` degrees away. Returns the original position if it is
+ * already a chord tone, or -1 if none is found within range (or no chord is
+ * given). Keeps melody movement subtle and diatonic (GEN-1).
+ */
+export function nearestChordToneScalePos(pos, chord, maxStep = 2) {
+    if(!chord)
+        return -1;
+    const tones = chordTonePitchClasses(chord);
+    const inScale = (i) => i >= 0 && i < fiveToFive.length;
+    const isTone = (i) => tones.has(mod12(fiveToFive[i]));
+    if(inScale(pos) && isTone(pos))
+        return pos;
+    for(let step = 1; step <= maxStep; step++) {
+        if(inScale(pos - step) && isTone(pos - step))
+            return pos - step;
+        if(inScale(pos + step) && isTone(pos + step))
+            return pos + step;
+    }
+    return -1;
+}

--- a/src/lib/engine/Drums/Hat.ts
+++ b/src/lib/engine/Drums/Hat.ts
@@ -8,14 +8,11 @@ const vol = new Tone.Volume(-9);
 const sw = new Tone.StereoWidener(0.7);
 
 class Hat {
+	sampler: Tone.Sampler;
 	constructor(cb) {
 		this.sampler = new Tone.Sampler(samples, () => {
 			cb();
-		}).chain(lpf,vol,sw,Tone.Master);
-	}
-
-	sampler() {
-		return this.sampler;
+		}).chain(lpf,vol,sw,Tone.getDestination());
 	}
 }
 

--- a/src/lib/engine/Drums/Kick.ts
+++ b/src/lib/engine/Drums/Kick.ts
@@ -6,14 +6,11 @@ const samples = {C4: samplePath};
 const vol = new Tone.Volume(-3);
 
 class Kick {
+	sampler: Tone.Sampler;
 	constructor(cb) {
 		this.sampler = new Tone.Sampler(samples, () => {
 			cb();
-		}).chain(vol,Tone.Master);
-	}
-
-	sampler() {
-		return this.sampler;
+		}).chain(vol,Tone.getDestination());
 	}
 }
 

--- a/src/lib/engine/Drums/Noise.ts
+++ b/src/lib/engine/Drums/Noise.ts
@@ -2,6 +2,6 @@ import * as Tone from 'tone';
 
 const lpf = new Tone.Filter(2000, "lowshelf");
 const vol = new Tone.Volume(-32);
-const noise = new Tone.Noise("pink").chain(lpf,vol,Tone.Master);
+const noise = new Tone.Noise("pink").chain(lpf,vol,Tone.getDestination());
 
 export default noise;

--- a/src/lib/engine/Drums/Snare.ts
+++ b/src/lib/engine/Drums/Snare.ts
@@ -8,14 +8,11 @@ const vol = new Tone.Volume(-6);
 const sw = new Tone.StereoWidener(0.3);
 
 class Snare {
+	sampler: Tone.Sampler;
 	constructor(cb) {
 		this.sampler = new Tone.Sampler(samples, () => {
 			cb();
-		}).chain(lpf,vol,sw,Tone.Master);
-	}
-
-	sampler() {
-		return this.sampler;
+		}).chain(lpf,vol,sw,Tone.getDestination());
 	}
 }
 

--- a/src/lib/engine/Piano/Piano.ts
+++ b/src/lib/engine/Piano/Piano.ts
@@ -5,14 +5,11 @@ const lpf = new Tone.Filter(1000, "lowpass");
 const sw = new Tone.StereoWidener(0.5);
 
 class Piano {
+	sampler: Tone.Sampler;
 	constructor(cb) {
 		this.sampler = new Tone.Sampler(Samples, () => {
 			cb();
-		}).chain(lpf,sw,Tone.Master);
-	}
-
-	sampler() {
-		return this.sampler;
+		}).chain(lpf,sw,Tone.getDestination());
 	}
 }
 

--- a/src/lib/locales/ru.ts
+++ b/src/lib/locales/ru.ts
@@ -1,4 +1,6 @@
-export const ru = {
+import type { Translations } from './types';
+
+export const ru: Translations = {
     settings: {
         title: 'Настройки',
         background: {

--- a/src/lib/locales/store.ts
+++ b/src/lib/locales/store.ts
@@ -18,6 +18,13 @@ const locales: Record<string, Translations> = {
     ru,
 };
 
+// Locales that render right-to-left. None ship today, but keeping the set
+// here means adding an RTL locale "just works" without touching the layout.
+const rtlLocales = new Set(['ar', 'he', 'fa', 'ur']);
+
+const dirFor = (lang: string): 'ltr' | 'rtl' =>
+    rtlLocales.has(lang) ? 'rtl' : 'ltr';
+
 const initialLocale = localStorage.getItem('locale') || 'en';
 
 export const locale = writable<string>(initialLocale);
@@ -26,8 +33,8 @@ export const t = derived(locale, ($locale) => {
     return locales[$locale] || locales['en'];
 });
 
-export const dir = derived(locale, () => {
-    return 'ltr';
+export const dir = derived(locale, ($locale) => {
+    return dirFor($locale);
 });
 
 export const setLocale = (lang: string) => {
@@ -35,7 +42,7 @@ export const setLocale = (lang: string) => {
         locale.set(lang);
         localStorage.setItem('locale', lang);
         // Update document direction immediately for better UX
-        document.documentElement.dir = 'ltr';
+        document.documentElement.dir = dirFor(lang);
         document.documentElement.lang = lang;
     }
 };

--- a/src/lib/stores/effects.ts
+++ b/src/lib/stores/effects.ts
@@ -1,0 +1,31 @@
+// Single source of truth for environmental effect on/off state (BUG-5).
+// Both the manual buttons/shortcuts, the context menu, and the Auto-DJ write
+// here; the effect components subscribe and play/pause to match. This replaces
+// the old stateless "lofi-toggle-*" CustomEvents, so the Auto-DJ can SET state
+// (not blindly flip) and reset what it enabled on mode change.
+import { writable } from 'svelte/store';
+
+export type EffectKey = 'rain' | 'thunder' | 'jungle' | 'campfire';
+export type EffectState = Record<EffectKey, boolean>;
+
+const DEFAULTS: EffectState = {
+  rain: false,
+  thunder: false,
+  jungle: false,
+  campfire: false,
+};
+
+// Not persisted: effects start off on each load (matches prior behavior).
+export const effects = writable<EffectState>({ ...DEFAULTS });
+
+export function setEffect(key: EffectKey, on: boolean) {
+  effects.update((s) => ({ ...s, [key]: on }));
+}
+
+export function toggleEffect(key: EffectKey) {
+  effects.update((s) => ({ ...s, [key]: !s[key] }));
+}
+
+export function resetEffects() {
+  effects.set({ ...DEFAULTS });
+}

--- a/src/lib/stores/volumes.ts
+++ b/src/lib/stores/volumes.ts
@@ -1,0 +1,40 @@
+// Single source of truth for ambient/main volumes (replaces the old
+// localStorage-polling approach — PERF-3). Auto-persists to the same
+// "Volumes" localStorage key for backward compatibility.
+import { writable } from 'svelte/store';
+
+export type VolumeKey = 'rain' | 'thunder' | 'campfire' | 'jungle' | 'main_track';
+export type Volumes = Record<VolumeKey, number>;
+
+const STORAGE_KEY = 'Volumes';
+const DEFAULTS: Volumes = {
+  rain: 1,
+  thunder: 1,
+  campfire: 1,
+  jungle: 1,
+  main_track: 1,
+};
+
+function load(): Volumes {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    return raw ? { ...DEFAULTS, ...JSON.parse(raw) } : { ...DEFAULTS };
+  } catch {
+    return { ...DEFAULTS };
+  }
+}
+
+export const volumes = writable<Volumes>(load());
+
+// Persist on every change.
+volumes.subscribe((v) => {
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(v));
+  } catch {
+    /* storage unavailable — ignore */
+  }
+});
+
+export function setVolume(key: VolumeKey, value: number) {
+  volumes.update((v) => ({ ...v, [key]: value }));
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from "vitest/config";
+
+// Dedicated Vitest config so the test runner does NOT load the Svelte/Tauri
+// vite.config.ts (which pulls in the Svelte plugin). The engine tests cover
+// pure, framework-free generation logic, so no DOM/Tone/Svelte is required.
+export default defineConfig({
+  test: {
+    include: ["src/lib/engine/**/*.test.ts"],
+    environment: "node",
+  },
+});


### PR DESCRIPTION
## Summary

The result of a comprehensive audit of the procedural generation engine and the app shell, followed by two waves of **fixes and refactors**. Adds an improvement tracker (`IMPROVEMENTS.md`) documenting the full set of findings with evidence and suggested fixes.

The headline fix is a **crash**: pressing **Space** while samples are still loading bypassed the load guards and started playback with an empty progression/scale — throwing in `playChord` and hitting an unbounded loop in the melody picker, which froze the tab. That path is now guarded (and unit-tested).

> Net-new **procedural-music features** (a synth bassline, drum-pattern variety, chord inversions/dynamics) are in a **separate follow-up PR** so this one stays focused on fixes/refactors that are easy to verify and merge.

## What's included

**Engine / generation**
- Fix the spacebar-during-load crash; bound + NaN-guard the melody weighted picker (extracted to `melodyHelpers.ts`)
- Remove dead method-shadows-field code on `Chord` and the instrument classes (also fixed pre-existing `svelte-check` failures)
- Simplify the play-button state machine; unlock the AudioContext only from a user gesture
- Chord-tone-aware melody, Fisher–Yates voicings, cadence-biased progressions, gentler swing, restore the master filter after transitions
- `Tone.Master` → `Tone.getDestination()`
- Add Vitest + engine unit tests

**Ambient tracks** — single source of truth for playback (unify click / number-key / Auto-DJ paths through one parent function), per-track volume persistence, cleanup on destroy

**Effects & lifecycle** — listeners moved into `onMount` with cleanup; reactive volume instead of `setInterval` polling; `play()` rejections caught; audio stopped on destroy

**State management** — new `stores/volumes.ts` and `stores/effects.ts` as single sources of truth, removing the localStorage-polling volume sync and the stateless `lofi-toggle-*` events; the Auto-DJ now manages effect state and resets only what it enabled on mode change

**Shell / i18n / security / docs** — fix a broken Tooltip listener removal; clear window-control polling/listeners; guard `JSON.parse` of stored state; type-annotate the Russian locale; add an explicit Tauri CSP; `rel="noopener"`; correct the README localization list; RTL-aware `dir`; ESC toggles the info box

See **`IMPROVEMENTS.md`** for the itemized list, severities, evidence, and verification verdicts.

## Verification

- `pnpm check` (svelte-check) → **0 errors** (1 pre-existing A11y warning in `ContextMenu`, untouched)
- `pnpm test` (Vitest) → **17/17 passing**
- `pnpm build` (vite) → **success**

## Notes for reviewers

- **Needs runtime verification:** the new Tauri **CSP** (`security.csp`) must be validated in a real `tauri build` — Tone.js may use blob/AudioWorklet workers and user images render as data-URLs. Loosen `worker-src`/`script-src` if anything is blocked.
- Commits are grouped by concern (engine, tracks, effects, shell, then the stores refactor) for easier review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
